### PR TITLE
fix(lightbox): restore finger-follow swipe via nested motion wrapper (Story 34.1)

### DIFF
--- a/e2e/lightbox-swipe-during-morph.spec.ts
+++ b/e2e/lightbox-swipe-during-morph.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect } from '@playwright/test'
+import {
+  seedHobby,
+  seedInventoryItem,
+  seedInventoryItemImage,
+  deleteHobbyCascade,
+  deleteInventoryItemsByPrefix,
+  type SeededHobby,
+  type SeededInventoryItem,
+} from './helpers/db-seed'
+
+/**
+ * Story 34.1 / FR132 — Lightbox finger-follow swipe regression test.
+ *
+ * The bug was a contest between Story 32.3's `<motion.img layoutId>` morph
+ * and Story 29.6's inline `transform: translateX(${dragOffset}px)` swipe
+ * style on the SAME DOM element. Framer Motion's projection writer wrote
+ * `transform: matrix(...)` directly to the img's `style.transform` for
+ * the morph window (~220 ms), clobbering the React-managed swipe
+ * transform.
+ *
+ * The fix splits the two transforms onto two DOM nodes:
+ *   - Outer `<motion.div layoutId>` drives the morph reveal.
+ *   - Inner `<img>` (no Framer wrapper) holds the swipe `translateX`.
+ *
+ * This test fires a synthetic touch swipe DURING the morph window and
+ * asserts the inner img's computed transform reflects 29.6's translateX
+ * — proving the two systems no longer contend.
+ */
+
+test.describe('Lightbox finger-follow swipe during morph (Story 34.1 / FR132)', () => {
+  test.describe.configure({ mode: 'serial' })
+  let hobby: SeededHobby
+  let item: SeededInventoryItem
+  let testPrefix: string
+
+  test.beforeAll(async ({ browserName }) => {
+    testPrefix = `LSDM-${browserName}-${Date.now()}`
+    hobby = await seedHobby({ name: `${testPrefix} Hobby`, color: 'hsl(200, 60%, 50%)' })
+    item = await seedInventoryItem({
+      name: `${testPrefix}-item`,
+      type: 'MATERIAL',
+      quantity: 1,
+      unit: 'kg',
+    })
+    // Two LINK images — picsum returns deterministic-ish content per seed.
+    // The `morphLayoutId` is set on the inventory hero (`inv-hero-${itemId}`)
+    // so opening the lightbox triggers the thumbnail-to-lightbox morph,
+    // which is the failure window we want to test.
+    await seedInventoryItemImage({
+      inventoryItemId: item.id,
+      type: 'LINK',
+      url: 'https://picsum.photos/seed/lsdm-a/400/400',
+    })
+    await seedInventoryItemImage({
+      inventoryItemId: item.id,
+      type: 'LINK',
+      url: 'https://picsum.photos/seed/lsdm-b/400/400',
+    })
+  })
+
+  test.afterAll(async () => {
+    await deleteInventoryItemsByPrefix(testPrefix)
+    await deleteHobbyCascade(hobby.id)
+  })
+
+  test('inner img translateX tracks finger during the morph window; scale stays 1.0', async ({
+    browser,
+  }) => {
+    const touchContext = await browser.newContext({
+      viewport: { width: 375, height: 812 },
+      hasTouch: true,
+      isMobile: true,
+    })
+    const touchPage = await touchContext.newPage()
+    await touchPage.goto('/inventory')
+    await touchPage.waitForLoadState('networkidle')
+
+    // Open the lightbox via the inventory hero — triggers the morph
+    // reveal driven by `morphLayoutId` on `<motion.div>` (post-Story-34.1).
+    await touchPage.getByRole('button', { name: `View photos of ${item.name}` }).click()
+
+    // Wait for the lightbox content to mount but NOT for the morph to
+    // settle — we want the swipe to fire WITHIN the morph window.
+    await expect(touchPage.getByTestId('image-lightbox')).toBeVisible({ timeout: 5000 })
+
+    // Run the swipe + matrix sampling in-browser. Each pointermove sets
+    // React state via `setDragOffset`; the inline-style commit only
+    // reaches the DOM after React's render flush. Awaiting `rAF` between
+    // dispatches gives the render a chance to land before sampling.
+    // This still keeps the entire gesture well inside the morph's
+    // ~220 ms window.
+    const samples = await touchPage.evaluate(async () => {
+      function parseMatrix(transform: string): {
+        a: number
+        b: number
+        c: number
+        d: number
+        e: number
+        f: number
+      } | null {
+        if (transform === 'none' || !transform) return null
+        const match = transform.match(/matrix\(([^)]+)\)/)
+        if (!match) return null
+        const parts = match[1].split(',').map((value) => parseFloat(value.trim()))
+        if (parts.length !== 6) return null
+        const [a, b, c, d, e, f] = parts
+        return { a, b, c, d, e, f }
+      }
+
+      function nextFrame() {
+        return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      }
+
+      const lightbox = document.querySelector(
+        '[data-testid="image-lightbox"]',
+      ) as HTMLElement | null
+      const innerImg = document.querySelector(
+        '[data-testid="lightbox-image"]',
+      ) as HTMLImageElement | null
+      if (!lightbox || !innerImg) {
+        return { ok: false as const, reason: 'lightbox or inner img not found' }
+      }
+
+      const rect = lightbox.getBoundingClientRect()
+      const startX = rect.left + rect.width * 0.7
+      const midY = rect.top + rect.height * 0.5
+
+      function fire(type: string, clientX: number, clientY: number) {
+        const event = new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerType: 'touch',
+          pointerId: 1,
+          clientX,
+          clientY,
+          isPrimary: true,
+        })
+        lightbox!.dispatchEvent(event)
+      }
+
+      const recorded: {
+        phase: string
+        img: ReturnType<typeof parseMatrix>
+        wrapper: ReturnType<typeof parseMatrix>
+      }[] = []
+
+      const wrapper = innerImg.parentElement as HTMLElement | null
+      if (!wrapper) {
+        return { ok: false as const, reason: 'inner img has no parent wrapper' }
+      }
+
+      function snapshot(phase: string) {
+        recorded.push({
+          phase,
+          img: parseMatrix(getComputedStyle(innerImg!).transform),
+          wrapper: parseMatrix(getComputedStyle(wrapper!).transform),
+        })
+      }
+
+      fire('pointerdown', startX, midY)
+      await nextFrame()
+      // Sample the wrapper's transform IMMEDIATELY after open — this
+      // captures Framer's morph-in-flight projection so the test fails
+      // loudly if a future regression moves the morph off the wrapper
+      // (i.e., back onto the same DOM node as the swipe transform).
+      snapshot('pointer-down')
+
+      fire('pointermove', startX - 30, midY)
+      await nextFrame()
+      snapshot('move-30')
+
+      fire('pointermove', startX - 80, midY)
+      await nextFrame()
+      snapshot('move-80')
+
+      fire('pointermove', startX - 150, midY)
+      await nextFrame()
+      snapshot('move-150')
+
+      // Release without committing — snap-back path.
+      fire('pointermove', startX - 20, midY)
+      fire('pointerup', startX - 20, midY)
+
+      return { ok: true as const, recorded }
+    })
+
+    if (!samples.ok) throw new Error(`swipe instrumentation failed: ${samples.reason}`)
+
+    // Each sample's inner-img matrix should reflect the swipe's translateX
+    // with scale of 1.0 (no Framer scale interpolation contention).
+    const pointerDown = samples.recorded.find((sample) => sample.phase === 'pointer-down')
+    const move30 = samples.recorded.find((sample) => sample.phase === 'move-30')
+    const move80 = samples.recorded.find((sample) => sample.phase === 'move-80')
+    const move150 = samples.recorded.find((sample) => sample.phase === 'move-150')
+
+    if (!pointerDown || !move30 || !move80 || !move150) {
+      throw new Error('expected one pointer-down sample + three move samples')
+    }
+    if (!move30.img || !move80.img || !move150.img) {
+      throw new Error(
+        `inner img has no transform matrix during move samples — Framer-vs-React contest may have re-emerged`,
+      )
+    }
+
+    // Regression-test core: at pointerdown (i.e., the moment swipe begins),
+    // the wrapper MUST be carrying a non-identity Framer matrix — that is
+    // proof the swipe is firing DURING the morph window. Without this
+    // assertion, a future regression that puts the swipe transform back
+    // onto the wrapper could pass the inner-img matrix checks below on
+    // warm-cache runs where the morph has already settled.
+    if (!pointerDown.wrapper) {
+      throw new Error('wrapper has no transform matrix at pointerdown — morph not in flight')
+    }
+    const wrapperIsIdentity =
+      Math.abs(pointerDown.wrapper.a - 1) < 0.001 &&
+      Math.abs(pointerDown.wrapper.d - 1) < 0.001 &&
+      Math.abs(pointerDown.wrapper.e) < 0.001 &&
+      Math.abs(pointerDown.wrapper.f) < 0.001
+    expect(
+      wrapperIsIdentity,
+      `expected wrapper to carry an in-flight Framer matrix at pointerdown (proof we are inside the morph window); got identity matrix instead — Framer morph is not on the wrapper or has already settled`,
+    ).toBe(false)
+
+    // translateX (matrix.e) tracks the move delta linearly. ±5 px slack
+    // accounts for axis-lock distance threshold and rounding.
+    expect(move30.img.e).toBeGreaterThanOrEqual(-35)
+    expect(move30.img.e).toBeLessThanOrEqual(-25)
+    expect(move80.img.e).toBeGreaterThanOrEqual(-85)
+    expect(move80.img.e).toBeLessThanOrEqual(-75)
+    expect(move150.img.e).toBeGreaterThanOrEqual(-155)
+    expect(move150.img.e).toBeLessThanOrEqual(-145)
+
+    // Scale (matrix.a, matrix.d) stays at 1.0 on the inner img — Framer's
+    // scale interpolation lives on the parent <motion.div>, not here.
+    for (const sample of [move30, move80, move150]) {
+      expect(sample.img!.a).toBeGreaterThanOrEqual(0.99)
+      expect(sample.img!.a).toBeLessThanOrEqual(1.01)
+      expect(sample.img!.d).toBeGreaterThanOrEqual(0.99)
+      expect(sample.img!.d).toBeLessThanOrEqual(1.01)
+    }
+
+    await touchContext.close()
+  })
+})

--- a/src/components/image/image-lightbox.tsx
+++ b/src/components/image/image-lightbox.tsx
@@ -409,15 +409,18 @@ export function ImageLightbox({
                   </div>
                 ) : (
                   <>
-                    {/* Story 32.3: motion.img with `layoutId` keyed by
-                        the image's stable id + a per-caller context
-                        suffix. The matching `layoutId` on the source
-                        thumbnail (set in each caller's <motion.img>)
-                        morphs from thumbnail position to lightbox
-                        position. Layout is gated OFF during swipe
-                        gestures so the inline transform from Story
-                        29.6 doesn't fight Framer's layout system. */}
-                    <motion.img
+                    {/* Story 34.1 (FR132): motion.div wrapper drives the
+                        layoutId morph reveal (Story 32.3); the inner
+                        <img> holds Story 29.6's swipe `translateX`
+                        inline style uncontested by Framer's projection.
+                        Splitting the two transforms onto separate DOM
+                        nodes lets them compose visually (CSS transforms
+                        cascade parent → child) instead of fighting on
+                        the same `style.transform` attribute. The
+                        `layout={!isDragging && !isCommitting}` gate is
+                        kept as defence in depth; the primary fix is the
+                        nesting. */}
+                    <motion.div
                       key={current.id}
                       // For the initially-shown image, use morphLayoutId
                       // when set (single-thumbnail callers); otherwise
@@ -425,6 +428,10 @@ export function ImageLightbox({
                       // gallery callers). After navigation, switch to
                       // per-image id (which won't match anything; close
                       // post-nav skips the morph as documented).
+                      // Framer's layoutId matches across element types
+                      // (motion.img source thumbnail ↔ motion.div
+                      // target wrapper) — the morph is bbox-driven, not
+                      // element-typed.
                       layoutId={
                         currentIndex === initialIndex && morphLayoutId
                           ? morphLayoutId
@@ -432,28 +439,33 @@ export function ImageLightbox({
                       }
                       layout={!isDragging && !isCommitting}
                       transition={tokens.transitions.layout}
-                      ref={(node) => {
-                        // Cached-image race: if the browser already had
-                        // this URL in cache, `onLoad` may have fired
-                        // before React attached its listener — leaving
-                        // `imageLoading` stuck at true. Check `complete`
-                        // synchronously on attach and clear if the image
-                        // is already decoded.
-                        if (node && node.complete && node.naturalWidth > 0) {
+                      className="inline-flex max-h-full max-w-full sm:max-h-[90vh] sm:max-w-[90vw]"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        ref={(node) => {
+                          // Cached-image race: if the browser already had
+                          // this URL in cache, `onLoad` may have fired
+                          // before React attached its listener — leaving
+                          // `imageLoading` stuck at true. Check `complete`
+                          // synchronously on attach and clear if the image
+                          // is already decoded.
+                          if (node && node.complete && node.naturalWidth > 0) {
+                            setImageLoading(false)
+                          }
+                        }}
+                        src={current.displayUrl}
+                        alt={current.originalFilename ?? ''}
+                        className="block max-h-full max-w-full object-contain"
+                        style={inlineImageStyle}
+                        onLoad={() => setImageLoading(false)}
+                        onError={() => {
+                          setBroken(true)
                           setImageLoading(false)
-                        }
-                      }}
-                      src={current.displayUrl}
-                      alt={current.originalFilename ?? ''}
-                      className="max-h-full max-w-full object-contain sm:max-h-[90vh] sm:max-w-[90vw]"
-                      style={inlineImageStyle}
-                      onLoad={() => setImageLoading(false)}
-                      onError={() => {
-                        setBroken(true)
-                        setImageLoading(false)
-                      }}
-                      data-testid="lightbox-image"
-                    />
+                        }}
+                        data-testid="lightbox-image"
+                      />
+                    </motion.div>
                     {imageLoading && (
                       <div
                         className="absolute inset-0 flex items-center justify-center bg-black/30 pointer-events-none"


### PR DESCRIPTION
Closes #11

## Summary

Story 34.1 / FR132. Restores Story 29.6's "image follows your finger" swipe behavior on the lightbox, broken since Story 32.3 introduced the Framer Motion `layoutId` morph reveal.

## Root cause

`<motion.img layoutId={…}>` and `style={{ transform: translateX(${dragOffset}px) }}` were on the SAME DOM node. Framer Motion's projection writer sets `style.transform = matrix(…)` directly on the element to drive the morph; that write clobbers the React-managed inline transform from 29.6 for the entire ~220ms morph window. The `layout={!isDragging && !isCommitting}` gate didn't help — `layoutId` itself drives projection independent of the `layout` boolean.

## Fix

Split the two transforms onto separate DOM nodes:

```tsx
<motion.div layoutId={…} layout={…} className="inline-flex …">  {/* Framer projection — morph reveal */}
  <img style={inlineImageStyle} … />                            {/* React-managed — swipe translateX */}
</motion.div>
```

CSS transforms compose parent → child. Both effects coexist with no UX trade-off:

- Wrapper interpolates from thumbnail bbox to lightbox bbox (Framer).
- Inner img tracks the finger linearly (React).
- The user sees BOTH simultaneously: morph reveal animates AND finger drags work, even from the very first pointermove during the morph window.

## Verification

Empirical matrix samples during the morph window (Playwright MCP, 375×812 viewport, gallery `/gallery/test`):

```
phase           innerImg.transform              wrapper.transform
move-30         matrix(1, 0, 0, 1, -30, 0)      matrix(0.788, 0, 0, 0.627, -49, -12)
move-80         matrix(1, 0, 0, 1, -80, 0)      matrix(0.814, 0, 0, 0.672, -43, -10)
move-150        matrix(1, 0, 0, 1, -150, 0)     matrix(0.869, 0, 0, 0.769, -30,  -7)
```

Inner img translateX (matrix.e) tracks finger linearly. Inner img scale stays 1.0. Parent independently morphs. Compare to the BEFORE measurements in #11 — Framer was winning at every move sample.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint` (one suppressed `@next/next/no-img-element` on the inner img per codebase convention)
- [x] `pnpm typecheck`
- [x] `pnpm test run` — 997/997 unit tests pass
- [x] `pnpm build` — clean
- [x] `pnpm test:e2e:chrome` — 183/183 pass
- [x] Manual smoke at 375×812 — swipe during morph works, swipe after morph works, snap-back works, commit-to-next works
- [x] Manual smoke on the gallery + step view + BOM thumbnail callers — morph reveal still plays correctly across all `morphLayoutId` patterns
- [x] New regression spec `e2e/lightbox-swipe-during-morph.spec.ts`:
  - Asserts wrapper carries non-identity Framer matrix at pointerdown (proof we are inside the morph window — locks in the regression contract; a future fix that moves swipe back onto the wrapper fails this test)
  - Asserts inner img translateX tracks deltas linearly within ±5 px slack
  - Asserts inner img scale stays at 1.0 (±0.01 tolerance) — no Framer scale interpolation contention

## Story / FR

- Story: `_bmad-output/implementation-artifacts/34-1-restore-lightbox-finger-follow-swipe.md`
- FR132 in PRD § "GitHub Issue Triage — Round 2 (Phase 20)"
- Epic 34 (Issue Triage Round 2): 34.1 → 34.2 (image ordering ASC) → 34.3 (drag handle inline)

## Notes

- Pre-existing parallel-load flake on `e2e/project-clone.spec.ts` (textarea detach during note fill) reproduced on the first full E2E run, did not reproduce on re-run, passes in isolation. Unrelated to lightbox; same flake class as the issues addressed in Stories 19.1 + 31.4.
- Root repo bmad-output artifacts are committed separately on root `main` (see `aine-sdd-project@2680a86`). Submodule pointer bump on root will land after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)