### PR TITLE
fix(lightbox): prefetch ± 1 images + stabilize size during Next/Prev (Story 34.4)

### DIFF
--- a/e2e/lightbox-prefetch.spec.ts
+++ b/e2e/lightbox-prefetch.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { seedHobby, seedProject, deleteHobbyCascade, type SeededHobby } from './helpers/db-seed'
+
+/**
+ * Story 34.4 / FR133 — Lightbox prefetch + size stabilization.
+ *
+ * The bug: clicking Next on the lightbox while the image is mid-fetch
+ * caused DialogContent (sm:w-auto sm:h-auto on desktop) to collapse,
+ * making the absolute-positioned controls (prev / next / close /
+ * delete / counter) clump in the middle of the viewport with the
+ * spinner on top.
+ *
+ * The fix: cache the previous image's rendered bounding box and apply
+ * as min-width/min-height on the image-area div while `imageLoading`
+ * is true. DialogContent stays sized to the previous photo's
+ * footprint until the new image arrives.
+ *
+ * This spec intercepts the second image's network request to delay it,
+ * forcing the slow-load path that the size-stabilization is meant to
+ * cover. Asserts the dialog box stays non-zero (and roughly the same
+ * size as before the click) during the delay window.
+ */
+
+test.describe('Lightbox prefetch + size stabilization (Story 34.4 / FR133)', () => {
+  test.describe.configure({ mode: 'serial' })
+  let hobby: SeededHobby
+  let projectId: string
+  let stepId: string
+  let testPrefix: string
+
+  // Use distinct picsum seeds so the two images have predictable
+  // distinct URLs we can intercept independently. The delayed URL is
+  // captured for the page.route handler.
+  const FIRST_IMAGE_SEED = 'lpx-first'
+  const SECOND_IMAGE_SEED = 'lpx-second'
+  const firstImageUrl = `https://picsum.photos/seed/${FIRST_IMAGE_SEED}/600/400`
+  const secondImageUrl = `https://picsum.photos/seed/${SECOND_IMAGE_SEED}/600/400`
+
+  test.beforeAll(async ({ browserName }) => {
+    testPrefix = `LPX-${browserName}-${Date.now()}`
+    hobby = await seedHobby({
+      name: `${testPrefix} Hobby`,
+      color: 'hsl(200, 60%, 50%)',
+    })
+    const seeded = await seedProject({
+      hobbyId: hobby.id,
+      name: `${testPrefix} Project`,
+      steps: [{ name: 'Step One' }],
+    })
+    projectId = seeded.project.id
+    stepId = seeded.steps[0].id
+
+    // Seed two LINK step images with explicit createdAt offsets — ASC
+    // ordering (FR131 / Story 34.2) means the first image is at index
+    // 0 and the second at index 1. Raw SQL pattern matches
+    // step-image-ordering.spec.ts and lightbox-backdrop-dismiss.spec.ts.
+    const pg = await import('pg')
+    const client = new pg.default.Client({
+      connectionString:
+        process.env.DATABASE_URL ?? 'postgresql://mindshed:mindshed@localhost:5432/mindshed_test',
+    })
+    await client.connect()
+    const baseTime = Date.now() - 2 * 60_000
+    const samples = [
+      { url: firstImageUrl, filename: 'first.jpg', offsetMs: 0 },
+      { url: secondImageUrl, filename: 'second.jpg', offsetMs: 60_000 },
+    ]
+    for (const sample of samples) {
+      await client.query(
+        `INSERT INTO step_image (id, step_id, type, url, original_filename, content_type, size_bytes, created_at)
+         VALUES ($1, $2, 'LINK', $3, $4, 'image/jpeg', 1000, to_timestamp($5 / 1000.0))`,
+        [randomUUID(), stepId, sample.url, sample.filename, baseTime + sample.offsetMs],
+      )
+    }
+    await client.end()
+  })
+
+  test.afterAll(async () => {
+    if (hobby?.id) await deleteHobbyCascade(hobby.id)
+  })
+
+  test('dialog stays sized during slow-load on Next; spinner shows; image renders on response', async ({
+    browser,
+  }) => {
+    // Use a fresh context so route interception doesn't leak between
+    // tests. Desktop viewport (1280×800) so DialogContent's
+    // sm:w-auto sm:h-auto path is the one under test (mobile path is
+    // 100dvh × 100vw and doesn't collapse).
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 800 },
+      storageState: 'e2e/.auth/state.json',
+    })
+    const page = await context.newPage()
+
+    // Delay the SECOND image's network response so the click-Next path
+    // hits the size-stabilization branch.
+    //
+    // Critical: the production `useEffect` issues a prefetch for
+    // `secondImageUrl` as soon as the FIRST image is at index 0 (i.e.
+    // immediately on lightbox open). That prefetch hits this route and
+    // the 3500 ms delay starts ticking. The test's "wait for first
+    // image to load + capture beforeBox + click Next" sequence runs in
+    // parallel, taking <1.5 s. So when the user clicks Next, the
+    // prefetch is STILL pending → the visible `<img>`'s request for
+    // `secondImageUrl` joins the same in-flight network operation
+    // (browser dedup), and the slow-load path is exercised
+    // deterministically. A short delay (~1500 ms) raced because the
+    // prefetch sometimes completed before click-Next.
+    await page.route(secondImageUrl, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 3500))
+      await route.continue()
+    })
+
+    try {
+      await page.goto(`/hobbies/${hobby.id}/projects/${projectId}`)
+      await page.waitForLoadState('networkidle')
+
+      // Open the lightbox via the FIRST thumbnail in the expanded
+      // step's image gallery (FR131: ASC order, index 0 = oldest).
+      const firstThumb = page.locator('[data-testid="image-gallery"] button img').first()
+      await expect(firstThumb).toBeVisible()
+      await firstThumb.click()
+
+      const lightboxImage = page.getByTestId('lightbox-image')
+      // Wait for the first image to fully load + render.
+      await expect(lightboxImage).toBeVisible({ timeout: 5000 })
+      await page.waitForFunction(
+        () => {
+          const img = document.querySelector(
+            '[data-testid="lightbox-image"]',
+          ) as HTMLImageElement | null
+          return img !== null && img.complete && img.naturalWidth > 0
+        },
+        undefined,
+        { timeout: 5000 },
+      )
+
+      // Capture the dialog content's bbox BEFORE click.
+      const dialogContent = page.getByTestId('image-lightbox')
+      const beforeBox = await dialogContent.boundingBox()
+      if (!beforeBox) throw new Error('dialog content bbox unavailable before click')
+      expect(beforeBox.width).toBeGreaterThan(100)
+      expect(beforeBox.height).toBeGreaterThan(100)
+
+      // Click Next — triggers the slow-load path because we delayed the
+      // second image's response by 1500 ms above.
+      await page.getByRole('button', { name: 'Next image' }).click()
+
+      // While the response is still in flight (~200 ms after click),
+      // the dialog SHOULD stay roughly the same size — this is the
+      // regression-test contract. Without size stabilization the
+      // dialog would collapse to near-zero on desktop.
+      await page.waitForTimeout(200)
+      const duringBox = await dialogContent.boundingBox()
+      if (!duringBox) throw new Error('dialog content bbox unavailable during load')
+      // ±20 px slack to account for any minor reflow.
+      expect(Math.abs(duringBox.width - beforeBox.width)).toBeLessThanOrEqual(20)
+      expect(Math.abs(duringBox.height - beforeBox.height)).toBeLessThanOrEqual(20)
+
+      // Spinner should be visible during the wait.
+      await expect(page.getByTestId('lightbox-image-loading')).toBeVisible()
+
+      // Wait for the delayed response to complete; assert the new
+      // image renders. (Counter advances to 2 of 2 immediately on
+      // click — that's React state, not gated on network.)
+      await expect(page.getByTestId('lightbox-counter')).toContainText('2 of 2')
+      await page.waitForFunction(
+        () => {
+          const img = document.querySelector(
+            '[data-testid="lightbox-image"]',
+          ) as HTMLImageElement | null
+          return img !== null && img.complete && img.naturalWidth > 0
+        },
+        undefined,
+        { timeout: 10_000 },
+      )
+      await expect(page.getByTestId('lightbox-image-loading')).not.toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/src/components/image/image-lightbox.tsx
+++ b/src/components/image/image-lightbox.tsx
@@ -102,6 +102,58 @@ export function ImageLightbox({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [goNext, goPrev])
 
+  // Story 34.4 / FR133 — prefetch the next + previous images so a
+  // Next/Prev click usually hits the browser cache. JS-side `Image()`
+  // (constructor) issues a real network request the browser caches the
+  // same way it would for a regular `<img src>`; this avoids the
+  // hidden-DOM-img failure mode an earlier (Story 29.6) attempt hit
+  // (browsers de-prioritise zero-size hidden imgs regardless of the
+  // `loading` attribute, so the cache wasn't reliably warm). The
+  // detached HTMLImageElement is GC-eligible after this effect returns;
+  // the browser keeps the cached response independently of the JS ref.
+  //
+  // Indices wrap modulo `total` to match `goNext`/`goPrev`'s
+  // wrap-around navigation — clicking Next from the last image lands
+  // on index 0, so we should prefetch index 0 from the last image too.
+  //
+  // `fetchPriority: 'low'` (NOT 'high') because this is a SPECULATIVE
+  // prefetch — high-priority would preempt the bandwidth of the
+  // currently-viewed image (which itself may not be fully loaded yet).
+  // 'low' tells the browser "warm the cache when you have idle
+  // capacity, but don't compete with foreground requests". Older
+  // browsers ignore the hint — graceful degradation.
+  useEffect(() => {
+    if (total < 2) return
+    const indicesToPrefetch = [(currentIndex + 1) % total, (currentIndex - 1 + total) % total]
+    for (const index of indicesToPrefetch) {
+      const url = images[index]?.displayUrl
+      if (!url) continue
+      const img = new window.Image()
+      ;(
+        img as HTMLImageElement & {
+          fetchPriority?: 'high' | 'low' | 'auto'
+        }
+      ).fetchPriority = 'low'
+      img.src = url
+    }
+  }, [currentIndex, images, total])
+
+  // Story 34.4 / FR133 — last-rendered bounding box of the inner img,
+  // captured in `onLoad` as state (NOT a ref — React 19's
+  // react-hooks/refs rule prohibits reading ref.current during render,
+  // which is exactly what the consumer below needs to do). Used as
+  // min-width/min-height on the image-area div while `imageLoading` is
+  // true so DialogContent (sized to its content via `sm:w-auto
+  // sm:h-auto` on desktop) doesn't collapse during the natural fetch
+  // on Next/Prev — preventing the absolute-positioned controls
+  // (prev/next/close/delete/counter) from clumping in the centre of
+  // the viewport. The extra render-per-onLoad is negligible (fires
+  // once per image, batched with `setImageLoading(false)`).
+  const [lastImageBox, setLastImageBox] = useState<{
+    width: number
+    height: number
+  } | null>(null)
+
   // Story 29.6 (revised): axis-locked sliding gesture with flick
   // detection.
   //
@@ -316,16 +368,21 @@ export function ImageLightbox({
         }
       : {}
 
-  // Story 29.6 (revised): the hidden-img prefetch was REMOVED after
-  // smoke testing — browsers de-prioritise zero-size hidden images and
-  // the prefetch wasn't reliably warming the cache. Worse, navigating
-  // showed no loading feedback during the actual fetch (browser kept
-  // the previous image visible until the new one arrived, which the
-  // user perceived as "the lightbox blocks navigation"). The fix is
-  // explicit loading state via `imageLoading` + a Loader2 overlay; the
-  // browser's natural fetch on src-change carries the navigation.
-  // If/when prefetch becomes worth revisiting, use `Image()` from JS
-  // with `fetchPriority: 'high'` rather than a hidden DOM <img>.
+  // Story 34.4 / FR133 — historical context: Story 29.6 originally
+  // shipped a hidden-DOM-`<img>` prefetch but it was REMOVED in the
+  // post-29.6 follow-up because browsers de-prioritise zero-size hidden
+  // imgs (Chromium specifically: hidden imgs get scheduled at 'low'
+  // priority regardless of the `loading` attribute), so the cache
+  // wasn't reliably warm by the time the user clicked Next. The
+  // current implementation uses the JS-side `Image()` constructor in a
+  // `useEffect` near the top of this component (search for "Story 34.4
+  // / FR133 — prefetch") which issues a real network request the
+  // browser caches normally; subsequent `<img src=...>` requests for
+  // the same URL hit the cache. Pair-fix: a `useRef` holds the
+  // previous image's rendered bounding box and is applied as
+  // min-width/min-height on the image-area div while `imageLoading` is
+  // true, so DialogContent doesn't collapse during the natural fetch
+  // on cold-cache navigations.
 
   return (
     <DialogPrimitive.Root
@@ -401,7 +458,27 @@ export function ImageLightbox({
             {/* Main image. Mobile fills the viewport with padding; desktop
                 hugs the image (the image is the size driver). */}
             <div className="flex h-full w-full flex-col items-center justify-center p-12 sm:h-auto sm:w-auto sm:p-0">
-              <div className="relative flex flex-1 items-center justify-center min-h-0 w-full sm:flex-none">
+              <div
+                className="relative flex flex-1 items-center justify-center min-h-0 w-full sm:flex-none"
+                // Story 34.4 / FR133 — while the new image is loading,
+                // hold this div at the previous image's rendered size so
+                // DialogContent doesn't collapse (sm:w-auto sm:h-auto
+                // sizes to content on desktop). Once the new image
+                // loads, `onLoad` updates the ref and `imageLoading`
+                // flips to false → the inline style drops, natural
+                // sizing takes over. First lightbox open (ref still
+                // null) preserves the existing collapse-then-expand
+                // behaviour — typical use is "open then navigate" so
+                // the expensive case is the navigation, not the open.
+                style={
+                  imageLoading && lastImageBox
+                    ? {
+                        minWidth: lastImageBox.width,
+                        minHeight: lastImageBox.height,
+                      }
+                    : undefined
+                }
+              >
                 {broken ? (
                   <div className="flex flex-col items-center gap-2 text-white/60">
                     <ImageIcon className="h-16 w-16" />
@@ -458,7 +535,23 @@ export function ImageLightbox({
                         alt={current.originalFilename ?? ''}
                         className="block max-h-full max-w-full object-contain"
                         style={inlineImageStyle}
-                        onLoad={() => setImageLoading(false)}
+                        onLoad={(event) => {
+                          // Story 34.4 / FR133 — capture the rendered
+                          // bbox (post-clip to max-h-[90vh] /
+                          // max-w-[90vw], not raw naturalWidth/Height)
+                          // so the next navigation can stabilize the
+                          // image-area div's size while the new image
+                          // loads. See the image-area div's `style`
+                          // prop above for the consumer.
+                          const rect = event.currentTarget.getBoundingClientRect()
+                          if (rect.width > 0 && rect.height > 0) {
+                            setLastImageBox({
+                              width: rect.width,
+                              height: rect.height,
+                            })
+                          }
+                          setImageLoading(false)
+                        }}
                         onError={() => {
                           setBroken(true)
                           setImageLoading(false)


### PR DESCRIPTION
Closes #15

## Summary

Story 34.4 / FR133. Two-part fix to the symptom *"all the controls (prev / next / close / delete) clump up in the middle of the screen with a spinner on top of them"* when clicking Next in the lightbox on desktop.

## Root cause

Two compounding factors:
1. **No prefetch.** Story 29.6 originally added a hidden-DOM-`<img>` prefetch but it was REMOVED because hidden imgs don't reliably warm the browser cache. Every Next/Prev hit the network from cold.
2. **DialogContent collapses on remount.** On desktop the dialog uses `sm:w-auto sm:h-auto` — sizes to content. The `<motion.div key={current.id}>` wrapper unmounts on every navigation; until the new `<img>` reports `naturalWidth`, the wrapper has no content; DialogContent shrinks; absolute-positioned controls converge.

## Fix

**Part 1 — Prefetch (preventive).** New `useEffect` on `currentIndex` warms `images[currentIndex ± 1]` (modulo `total` to match `goNext`/`goPrev`'s wrap-around) via `new window.Image()` with `fetchPriority: 'low'`. Speculative — must not preempt the in-viewport image's bandwidth; `'low'` is the correct hint.

**Part 2 — Size stabilization (defensive).** New `useState lastImageBox` captures the inner img's `getBoundingClientRect()` in `onLoad`. While `imageLoading` is true AND `lastImageBox` is non-null, the image-area div applies `style={{ minWidth, minHeight }}` from the captured box. DialogContent stays sized to the previous photo's footprint; controls keep their pre-navigation positions. First lightbox open (no prior box) preserves the existing collapse-then-expand behaviour.

State (not ref) because React 19's `react-hooks/refs` rule prohibits reading `ref.current` during render — which is exactly the consumer pattern.

## Verification (manual smoke at desktop 1280×800)

```
phase                     dialogContent.boundingBox
before-click             437×650 px
during (~50ms after)     991×697 px (image2 already cache-hit from prefetch)
after-stable             1024×720 px
```

The "during" sample shows the dialog at near-final size — confirming the prefetch worked. The size-stabilization safety net is for cold-cache misses where the load takes >100ms; in real usage with prefetch warming, that path is rarely hit. The E2E uses `page.route` with a 3500 ms delay to deterministically exercise it.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test run` — 1003/1003 unit tests pass
- [x] `pnpm build` — clean
- [x] `pnpm test:e2e:chrome` — 185/185 pass (incl. new `lightbox-prefetch.spec.ts`)

**New E2E spec** intercepts the second image's URL with a 3500 ms delay to outrun the production prefetch race; clicks Next; asserts (a) dialog stays sized within ±20 px of the previous size during the delay window (size-stab works), (b) spinner is visible during the wait, (c) new image renders post-response.

## Story / FR

- Story: `_bmad-output/implementation-artifacts/34-4-lightbox-prefetch-and-skeleton.md`
- FR133 in PRD § "GitHub Issue Triage — Round 2 (Phase 20)"
- Epic 34 (Issue Triage Round 2) reopened: 34.1 / 34.2 / 34.3 done → **34.4 (this PR)**

## Notes

- **`fetchPriority` corrected from spec.** Spec Task 1.2 prescribed `'high'` per the breadcrumb left in the original 29.6 comment. Code review correctly caught that `'high'` is wrong for speculative prefetch — it would preempt the bandwidth of the currently-viewed image. Switched to `'low'`. Documented inline.
- **State instead of ref.** Spec Task 2 prescribed `useRef`. ESLint's `react-hooks/refs` rule blocks reading `ref.current` during render (which the consumer does). State works, batches with `setImageLoading(false)`, render cost is one extra render per `onLoad` (negligible).
- **Wrap-around prefetch.** Spec used strict `±1`; implementation uses modulo so the last image's "next" prefetches index 0, matching `goNext`'s wrap behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)