### PR TITLE
fix(layout): drop AnimatePresence from RouteTransition (closes #17)

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -64,4 +64,71 @@ test.describe('Navigation', () => {
     // Breadcrumb has Dashboard link
     await expect(page.getByLabel('breadcrumb').getByText('Dashboard')).toBeVisible()
   })
+
+  // Issue #17 regression: an `AnimatePresence mode="wait"` wrapper around
+  // the keyed route content could leave the freshly-mounted child
+  // latched onto the exiting child's in-flight motion values under App
+  // Router's RSC streaming — the new page mounted at `opacity: 0;
+  // translateY(-8px)` and never advanced to `animate`, leaving the
+  // route blank until a viewport resize forced a repaint. The fix
+  // removes `AnimatePresence` so React reconciles the key change as
+  // unmount → mount and the new wrapper always runs its own
+  // initial → animate cycle, settling at opacity 1.
+  //
+  // `reducedMotion: 'no-preference'` is pinned because Framer collapses
+  // transitions to instant under reduced motion, which would make the
+  // assertion trivially green and miss a regression. In Playwright
+  // 1.59 this option lives on `contextOptions`, not directly on
+  // PlaywrightTestOptions.
+  test.use({ contextOptions: { reducedMotion: 'no-preference' } })
+
+  test('route transition wrapper is visible after repeated client-side navigations', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const wrappers = page.getByTestId('route-transition')
+    const header = page.locator('header')
+
+    // Alternate Inventory ↔ Settings via the top-bar links six times.
+    // Pre-fix, the second-or-later landing on a route would leave the
+    // wrapper stuck at `opacity: 0; transform: translateY(-8px)`.
+    const targets: Array<{
+      name: 'Inventory' | 'Settings'
+      url: string
+      heading: string
+    }> = [
+      { name: 'Inventory', url: '/inventory', heading: 'Inventory' },
+      { name: 'Settings', url: '/settings', heading: 'Settings' },
+      { name: 'Inventory', url: '/inventory', heading: 'Inventory' },
+      { name: 'Settings', url: '/settings', heading: 'Settings' },
+      { name: 'Inventory', url: '/inventory', heading: 'Inventory' },
+      { name: 'Settings', url: '/settings', heading: 'Settings' },
+    ]
+
+    for (const target of targets) {
+      await header.getByRole('link', { name: target.name }).click()
+      await expect(page).toHaveURL(target.url)
+
+      // The wrapper's opacity must settle at ~1 (allow tiny float
+      // imprecision) within the slide duration plus a generous CI
+      // buffer. Pre-fix, this stayed at 0 indefinitely.
+      // `.last()` picks the most recently mounted wrapper; bare keyed
+      // motion.div should yield exactly one, but `.last()` is robust if
+      // an animation library briefly retains an exiting node.
+      await expect
+        .poll(() => wrappers.last().evaluate((el) => parseFloat(getComputedStyle(el).opacity)), {
+          timeout: 5000,
+        })
+        .toBeGreaterThanOrEqual(0.99)
+
+      // Stronger user-facing assertion: the page heading is actually
+      // visible. A wrapper at opacity 1 is necessary but not sufficient
+      // proof the route rendered — this catches regressions where the
+      // wrapper paints but children fail.
+      await expect(page.getByRole('heading', { name: target.heading })).toBeVisible()
+    }
+  })
 })

--- a/src/components/layout/route-transition.tsx
+++ b/src/components/layout/route-transition.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { AnimatePresence, motion } from 'motion/react'
+import { motion } from 'motion/react'
 import { useMotionTokens } from '@/lib/motion/motion-tokens'
 
 interface RouteTransitionProps {
@@ -11,10 +11,11 @@ interface RouteTransitionProps {
 /**
  * Story 32.5 — fades + slides the `(app)` route content on navigation.
  *
- * Keyed by `usePathname()` so AnimatePresence sees a different child key
- * on each route change and runs the exit/enter cycle. Uses the
- * `default` motion token (220ms) with the standard easing so timing
- * aligns with dialog open/close and toast in/out elsewhere.
+ * Keyed by `usePathname()` so React reconciles a key change as
+ * `unmount old → mount new`, after which the new `motion.div` runs its
+ * `initial → animate` cycle. Uses the `default` motion token (220ms)
+ * with the standard easing so timing aligns with dialog open/close and
+ * toast in/out elsewhere.
  *
  * Honours `prefers-reduced-motion: reduce` automatically — the
  * `<MotionConfig reducedMotion="user">` boundary at the app root
@@ -25,22 +26,35 @@ interface RouteTransitionProps {
  * shallow updates within the same segment). The transition is best-
  * effort; if a navigation skips it, the page content still appears
  * — the worst case is "no animation," not "broken nav."
+ *
+ * Issue #17: there is intentionally NO `AnimatePresence` here. The
+ * earlier `AnimatePresence mode="wait"` setup could leave a
+ * freshly-mounted keyed child latched onto the exiting child's
+ * in-flight motion values under App Router's RSC streaming — the new
+ * page would mount at `opacity: 0; translateY(-8px)` (the exit state)
+ * and never advance to `animate`, leaving the route blank until a
+ * viewport resize forced a repaint. Dropping `mode="wait"` removed the
+ * stuck-state but left two full route subtrees in the DOM during the
+ * 220ms exit overlap (layout doubled, effects double-fired, `id`
+ * attributes could collide). Removing `AnimatePresence` altogether
+ * eliminates both failure modes: there is no exit cycle to leak
+ * values, and React unmounts the old subtree before mounting the new
+ * one — no overlap, no orphaned effects. The only thing lost is the
+ * exit animation; the entering page still slides + fades in.
  */
 export function RouteTransition({ children }: RouteTransitionProps) {
   const pathname = usePathname()
   const tokens = useMotionTokens()
 
   return (
-    <AnimatePresence mode="wait">
-      <motion.div
-        key={pathname}
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -8 }}
-        transition={tokens.transitions.slide}
-      >
-        {children}
-      </motion.div>
-    </AnimatePresence>
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={tokens.transitions.slide}
+      data-testid="route-transition"
+    >
+      {children}
+    </motion.div>
   )
 }


### PR DESCRIPTION
## Summary

- Fixes [#17](https://github.com/JohanX/mindshed/issues/17): inventory (and other `(app)` routes) rendering blank after repeated client-side navigations on Vercel.
- Root cause: `AnimatePresence mode="wait"` in `src/components/layout/route-transition.tsx` (Story 32.5) was leaving the freshly-mounted keyed child latched onto the exiting child's in-flight motion values under App Router's RSC streaming — the new page mounted at `opacity: 0; translateY(-8px)` (the exit state) and never advanced to `animate`. A viewport resize forced a repaint and content reappeared.
- Fix: removed `<AnimatePresence>` entirely. With a bare keyed `<motion.div>`, React reconciles the key change as unmount → mount and the new wrapper runs its own `initial → animate` cycle. This also avoids the dual-DOM overlap that dropping just `mode="wait"` would have introduced (layout doubling, duplicate effects, possible `id` collisions). Trade-off: no exit animation; entering page still slides + fades in.
- Diagnosis verified live on production via Playwright: pre-fix the wrapper stayed stuck at `opacity: 0` 1.5s after navigation; post-fix it settles at `opacity: 1` after every navigation.
- Regression test added in `e2e/navigation.spec.ts` — alternates Inventory ↔ Settings six times and asserts wrapper opacity ≥ 0.99 + heading visible. Pins `reducedMotion: 'no-preference'` so 0-duration transitions can't make the assertion trivially green.

## Files changed

- `src/components/layout/route-transition.tsx` — drop `AnimatePresence`; keep keyed `motion.div` with `initial` + `animate`; add `data-testid="route-transition"`; rewrite the comment to explain why no `AnimatePresence`.
- `e2e/navigation.spec.ts` — new regression test.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test run` — 1003 passed
- [x] `pnpm build`
- [x] `pnpm test:e2e:chrome -g "route transition wrapper"` — 2 passed
- [x] Full chromium navigation suite — 11 of 12 pass; the one failure (`epic-14/gallery-controls.spec.ts:104` "gallery toggles persist…") is a pre-existing test-ordering issue (test references `projectUrl` from earlier tests in the file) that reproduces on `main` and is unrelated to this PR.
- [x] Manual: live diagnosis on https://mindshed.johan.ro confirmed the bug pre-fix; the fix's invariant (wrapper settles at opacity 1) verified locally on the dev server.
- [ ] Vercel preview spot-check after merge: navigate Hobby → Inventory → Hobby → Inventory and confirm the inventory page paints every time.

## Code review notes

Ran `bmad-code-review` (Blind Hunter + Edge Case Hunter). Reviewers flagged: dual-DOM overlap during exit, layout doubling, duplicate effects, test float-precision, reduced-motion false-green, `.first()` vs `.last()` ordering during overlap, missing heading-visible assertion. All addressed by removing `AnimatePresence` (kills the overlap entirely) and by tightening the test (pinned reduced motion, ≥ 0.99 tolerance, `.last()`, heading-visible assertion). Three findings deferred (pathname=null first paint, popstate test, spam-click memory) — captured below.

## Deferred follow-ups (not in this PR)

- popstate (browser back/forward) regression test for the same invariant.
- `usePathname()` returning `null`/`""` on the first paint.
- Throttling/coalescing rapid route clicks (now mostly moot without `AnimatePresence`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)