### PR TITLE
fix(lightbox): viewport-anchored controls + clean press + no auto-focus ring (closes #19)

### DIFF
--- a/e2e/lightbox-controls.spec.ts
+++ b/e2e/lightbox-controls.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '@playwright/test'
+import { seedHobby, seedProject, deleteHobbyCascade } from './helpers/db-seed'
+
+// Issue #19 — lightbox controls polish.
+//
+// 1. Buttons must sit at consistent VIEWPORT-relative positions
+//    regardless of image size. Pre-fix, controls were `absolute` to
+//    the DialogContent which shrinks to wrap the image (Story 29.1) —
+//    small images put the buttons on top of the image. The fix uses
+//    `position: fixed` on the controls so they're positioned relative
+//    to the viewport. The lightbox open/close keyframes were also
+//    changed from scale+opacity to opacity-only because a `transform`
+//    on a `fixed` descendant's ancestor establishes a new containing
+//    block that breaks the viewport positioning during the animation.
+// 2. Opening the lightbox via mouse click must not leave the close
+//    button focused. Pre-fix, Radix auto-focused the first focusable
+//    inside Content (the close button), and browsers matched
+//    `:focus-visible` on that programmatic focus, so the close button
+//    got an orange ring on every mouse-click open. The fix passes
+//    `onOpenAutoFocus={(e) => e.preventDefault()}` so Radix skips the
+//    initial focus move; Tab still drops focus into the dialog as
+//    expected (real keyboard nav DOES light the ring, intentionally).
+// 3. Clicking a control must not dismiss the dialog. Controls remain
+//    DOM children of Content, so Radix's outside-click logic correctly
+//    treats them as "inside" — but the test guards against future
+//    refactors that move controls out without restoring the dismissal
+//    suppression.
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('Lightbox controls polish (issue #19)', () => {
+  let testPrefix: string
+  let hobbyId: string
+  let projectId: string
+
+  test.beforeAll(async ({ browserName }) => {
+    testPrefix = `LB-CTRL-${browserName}-${Date.now()}`
+
+    const hobby = await seedHobby({
+      name: `${testPrefix} Hobby`,
+      color: 'hsl(25, 45%, 40%)',
+    })
+    hobbyId = hobby.id
+
+    const seeded = await seedProject({
+      hobbyId,
+      name: `${testPrefix} Project`,
+      steps: [{ name: 'Step with images', state: 'IN_PROGRESS' }],
+    })
+    projectId = seeded.project.id
+    const stepId = seeded.steps[0].id
+
+    // Seed two images at very different sizes so we can prove button
+    // placement is invariant. The first is small (300×450) — the case
+    // that triggered the original symptom because DialogContent
+    // shrinks to wrap it. The second is large (1600×1200).
+    const pg = await import('pg')
+    const client = new pg.default.Client({
+      connectionString:
+        process.env.DATABASE_URL ?? 'postgresql://mindshed:mindshed@localhost:5432/mindshed_test',
+    })
+    await client.connect()
+    await client.query(
+      `INSERT INTO step_image (id, step_id, type, url, original_filename, content_type, size_bytes, created_at)
+       VALUES ($1, $2, 'LINK', 'https://picsum.photos/seed/lb-ctrl-small/300/450', 'small.jpg', 'image/jpeg', 12345, now())`,
+      [crypto.randomUUID(), stepId],
+    )
+    await client.query(
+      `INSERT INTO step_image (id, step_id, type, url, original_filename, content_type, size_bytes, created_at)
+       VALUES ($1, $2, 'LINK', 'https://picsum.photos/seed/lb-ctrl-large/1600/1200', 'large.jpg', 'image/jpeg', 12345, now() + interval '1 second')`,
+      [crypto.randomUUID(), stepId],
+    )
+    await client.end()
+  })
+
+  test.afterAll(async () => {
+    if (hobbyId) await deleteHobbyCascade(hobbyId)
+  })
+
+  test('controls sit at viewport edges regardless of image size', async ({ page }) => {
+    const viewport = { width: 1280, height: 800 }
+    await page.setViewportSize(viewport)
+    await page.goto(`/hobbies/${hobbyId}/projects/${projectId}`)
+    await page.waitForLoadState('networkidle')
+
+    // Scope to the View buttons only — the gallery also renders an
+    // overlapping delete button per item, so a bare `button` selector
+    // would match twice as many elements as there are images.
+    const thumbnails = page.locator('[data-testid="image-gallery"] button[aria-label^="View"]')
+    await expect(thumbnails.first()).toBeVisible()
+
+    // The two thumbnails are ordered by createdAt asc (Story 34.2);
+    // the small image was inserted first, so it's index 0.
+    for (const index of [0, 1]) {
+      await thumbnails.nth(index).click()
+
+      const lightbox = page.getByTestId('image-lightbox')
+      await expect(lightbox).toBeVisible({ timeout: 5000 })
+
+      // Wait for the lightbox image to be loaded and the open animation
+      // to settle so the controls have their final layout.
+      const image = page.getByTestId('lightbox-image')
+      await expect(image).toBeVisible()
+
+      const close = page.getByTestId('lightbox-close')
+      const prev = page.getByTestId('lightbox-prev')
+      const next = page.getByTestId('lightbox-next')
+
+      // Close: 12 px (right-3) + 44 px (h-11 w-11) = right edge 12 px
+      // from viewport right. Allow a few px slop for sub-pixel rounding.
+      await expect
+        .poll(async () => {
+          const box = await close.boundingBox()
+          return box ? viewport.width - (box.x + box.width) : Infinity
+        })
+        .toBeLessThan(20)
+
+      // Prev: left edge ~12 px from viewport left.
+      await expect
+        .poll(async () => {
+          const box = await prev.boundingBox()
+          return box ? box.x : Infinity
+        })
+        .toBeLessThan(20)
+
+      // Next: right edge ~12 px from viewport right.
+      await expect
+        .poll(async () => {
+          const box = await next.boundingBox()
+          return box ? viewport.width - (box.x + box.width) : Infinity
+        })
+        .toBeLessThan(20)
+
+      // Close the lightbox before the next iteration.
+      await page.keyboard.press('Escape')
+      await expect(lightbox).toBeHidden({ timeout: 2000 })
+    }
+  })
+
+  test('mouse-click open does not focus the close button', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto(`/hobbies/${hobbyId}/projects/${projectId}`)
+    await page.waitForLoadState('networkidle')
+
+    const thumbnail = page
+      .locator('[data-testid="image-gallery"] button[aria-label^="View"]')
+      .first()
+    await thumbnail.click()
+
+    const lightbox = page.getByTestId('image-lightbox')
+    await expect(lightbox).toBeVisible({ timeout: 5000 })
+
+    // Pre-fix, Radix's auto-focus put `.focus()` on the first
+    // focusable inside Content (the close button). Browsers match
+    // `:focus-visible` on that programmatic focus, so the close button
+    // got an orange ring on every mouse-click open. With controls
+    // moved out of Content (issue #19), the only focusable inside
+    // Content is now the dialog itself — Radix's focus trap falls
+    // back to focusing Content (which has `outline-none`). Both
+    // assertions below should hold:
+    //
+    //   • the active element is not the close button (heuristic-
+    //     independent — checks DOM focus directly), and
+    //   • `:focus-visible` does not match on the close button.
+    const closeIsActive = await page.evaluate(() => {
+      const close = document.querySelector('[data-testid="lightbox-close"]')
+      return close !== null && document.activeElement === close
+    })
+    expect(closeIsActive).toBe(false)
+
+    const closeFocusVisible = await page
+      .getByTestId('lightbox-close')
+      .evaluate((el) => el.matches(':focus-visible'))
+    expect(closeFocusVisible).toBe(false)
+  })
+
+  test('clicking a control does NOT close the lightbox', async ({ page }) => {
+    // Controls are DOM children of DialogContent (positioned via
+    // `fixed` against the viewport, but DOM-wise inside Content). A
+    // click on Next must advance the counter and keep the dialog
+    // open — the regression to guard against is a future refactor
+    // moving controls outside Content without preserving Radix's
+    // outside-click suppression.
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto(`/hobbies/${hobbyId}/projects/${projectId}`)
+    await page.waitForLoadState('networkidle')
+
+    const thumbnail = page
+      .locator('[data-testid="image-gallery"] button[aria-label^="View"]')
+      .first()
+    await thumbnail.click()
+
+    const lightbox = page.getByTestId('image-lightbox')
+    await expect(lightbox).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('lightbox-image')).toBeVisible()
+
+    // Click Next — the dialog must remain visible and the counter
+    // must advance to the second image.
+    await page.getByTestId('lightbox-next').click()
+    await expect(lightbox).toBeVisible()
+    await expect(page.getByTestId('lightbox-counter')).toContainText('2 of 2')
+  })
+})

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -306,17 +306,41 @@
  *   - dialog/alert-dialog: medium (220ms) — body-of-the-app modals
  *   - dropdown/popover: fast (150ms) — should feel responsive, not slow
  *
- * All four classes use the same anim-reveal/anim-settle keyframes; only
- * the duration token differs. Apply by adding the class alongside the
- * existing data-state-driven Tailwind classes; the data-state attribute
- * selectors here drive the animation. */
+ * Dialog/popup surfaces use the shared `anim-reveal` / `anim-settle`
+ * keyframes (opacity + small scale). The lightbox uses dedicated
+ * opacity-only keyframes — see Issue #19: the lightbox needs to
+ * position controls via `position: fixed` against the viewport, and a
+ * `transform` on the lightbox content/overlay would establish a new
+ * containing block that breaks `fixed` positioning during the
+ * animation. The 5% scale change is barely perceptible at lightbox
+ * size; opacity alone gives essentially the same visual fade.
+ *
+ * Apply by adding the class alongside the existing data-state-driven
+ * Tailwind classes; the data-state attribute selectors here drive the
+ * animation. */
+@keyframes anim-lightbox-reveal {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes anim-lightbox-settle {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
 .anim-lightbox-content[data-state='open'],
 .anim-lightbox-overlay[data-state='open'] {
-  animation: anim-reveal var(--anim-duration-slow) var(--anim-easing);
+  animation: anim-lightbox-reveal var(--anim-duration-slow) var(--anim-easing);
 }
 .anim-lightbox-content[data-state='closed'],
 .anim-lightbox-overlay[data-state='closed'] {
-  animation: anim-settle var(--anim-duration-slow) var(--anim-easing);
+  animation: anim-lightbox-settle var(--anim-duration-slow) var(--anim-easing);
 }
 
 .anim-dialog-content[data-state='open'],

--- a/src/components/image/image-lightbox.tsx
+++ b/src/components/image/image-lightbox.tsx
@@ -144,11 +144,15 @@ export function ImageLightbox({
   // which is exactly what the consumer below needs to do). Used as
   // min-width/min-height on the image-area div while `imageLoading` is
   // true so DialogContent (sized to its content via `sm:w-auto
-  // sm:h-auto` on desktop) doesn't collapse during the natural fetch
-  // on Next/Prev — preventing the absolute-positioned controls
-  // (prev/next/close/delete/counter) from clumping in the centre of
-  // the viewport. The extra render-per-onLoad is negligible (fires
-  // once per image, batched with `setImageLoading(false)`).
+  // sm:h-auto` on desktop) doesn't visibly collapse during the natural
+  // fetch on Next/Prev — keeping the image area at the previous
+  // photo's footprint avoids a jarring shrink-then-grow as the new
+  // image loads. Issue #19 made the controls' layout independent of
+  // Content's size (they're `fixed` to the viewport now), so this
+  // stabilization no longer affects control placement — but it still
+  // matters for the image area itself. The extra render-per-onLoad is
+  // negligible (fires once per image, batched with
+  // `setImageLoading(false)`).
   const [lastImageBox, setLastImageBox] = useState<{
     width: number
     height: number
@@ -414,6 +418,15 @@ export function ImageLightbox({
             // block pinch-zoom on the lightbox image — a usability
             // regression for users who want to zoom into details.
             className="anim-lightbox-content relative flex h-[100dvh] w-screen max-w-full touch-[pan-y_pinch-zoom] flex-col items-center justify-center gap-0 rounded-none border-none bg-black/95 p-0 outline-none sm:h-auto sm:max-h-[90vh] sm:w-auto sm:max-w-[90vw] sm:rounded-md sm:bg-transparent"
+            // Issue #19 — suppress Radix's auto-focus on open. Without
+            // this, the first focusable inside Content (the close
+            // button) gets a programmatic .focus() that browsers match
+            // as `:focus-visible`, so opening the lightbox by mouse
+            // showed an orange focus ring on close. Tab into the
+            // dialog still works (Radix's focus trap is still active
+            // on Tab); keyboard users see rings as intended on real
+            // keyboard nav.
+            onOpenAutoFocus={(event) => event.preventDefault()}
             // Story 29.6: swipe gesture on touch devices — left = next,
             // right = prev. Coexists with on-screen arrows + keyboard.
             onPointerDown={handlePointerDown}
@@ -427,8 +440,41 @@ export function ImageLightbox({
               </DialogPrimitive.Title>
             </VisuallyHidden.Root>
 
+            {/* Issue #19 — controls are positioned with `fixed`
+                (relative to the viewport), NOT `absolute` (which would
+                resolve relative to the shrunk DialogContent and put
+                them on top of small images). Controls remain DOM
+                children of Content so:
+                  • Radix's outside-click logic correctly treats them
+                    as inside (no `onPointerDownOutside` workaround
+                    needed),
+                  • Radix's `aria-hidden` modal management leaves them
+                    visible to screen readers (only siblings of
+                    Content inside Portal get marked aria-hidden),
+                  • the focus trap covers them naturally.
+
+                The lightbox open/close keyframes (`anim-lightbox-*`,
+                see globals.css) are defined opacity-only (no
+                `transform: scale`) precisely so this `fixed`
+                positioning resolves to the viewport throughout the
+                animation. A `transform` on Content would establish a
+                new containing block for `fixed` descendants and the
+                buttons would visibly jump to the viewport edges at
+                end-of-animation.
+
+                For the prev/next arrows the `-translate-y-1/2` lives
+                on the wrapper div, NOT on the Button itself. Tailwind
+                v4 stores translate-x and translate-y in a single CSS
+                variable; applying `-translate-y-1/2` (centering) AND
+                `active:translate-y-px` (the Button's press cue) on
+                the same element makes the press REPLACE the
+                centering, dropping the button by ~22 px on press —
+                and the cursor lands on empty space, so slow clicks
+                stop firing. Splitting transforms onto two elements
+                composes cleanly. */}
+
             {/* Top-right controls: delete + close */}
-            <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+            <div className="fixed right-3 top-3 z-50 flex items-center gap-2">
               {showDelete && (
                 <ImageDeleteButton
                   imageId={current.id}
@@ -449,7 +495,7 @@ export function ImageLightbox({
 
             {/* Image counter */}
             <div
-              className="absolute left-1/2 top-4 z-10 -translate-x-1/2 rounded-full bg-black/60 px-3 py-1 text-sm text-white"
+              className="fixed left-1/2 top-4 z-50 -translate-x-1/2 rounded-full bg-black/60 px-3 py-1 text-sm text-white"
               data-testid="lightbox-counter"
             >
               {currentIndex + 1} of {total}
@@ -594,30 +640,34 @@ export function ImageLightbox({
 
             {/* Previous arrow */}
             {total > 1 && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute left-3 top-1/2 z-10 h-11 w-11 -translate-y-1/2 rounded-full bg-black/50 supports-backdrop-filter:backdrop-blur-sm text-white hover:bg-black/70"
-                onClick={goPrev}
-                aria-label="Previous image"
-                data-testid="lightbox-prev"
-              >
-                <ChevronLeft className="h-6 w-6" />
-              </Button>
+              <div className="fixed left-3 top-1/2 z-50 -translate-y-1/2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-11 w-11 rounded-full bg-black/50 supports-backdrop-filter:backdrop-blur-sm text-white hover:bg-black/70"
+                  onClick={goPrev}
+                  aria-label="Previous image"
+                  data-testid="lightbox-prev"
+                >
+                  <ChevronLeft className="h-6 w-6" />
+                </Button>
+              </div>
             )}
 
             {/* Next arrow */}
             {total > 1 && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute right-3 top-1/2 z-10 h-11 w-11 -translate-y-1/2 rounded-full bg-black/50 supports-backdrop-filter:backdrop-blur-sm text-white hover:bg-black/70"
-                onClick={goNext}
-                aria-label="Next image"
-                data-testid="lightbox-next"
-              >
-                <ChevronRight className="h-6 w-6" />
-              </Button>
+              <div className="fixed right-3 top-1/2 z-50 -translate-y-1/2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-11 w-11 rounded-full bg-black/50 supports-backdrop-filter:backdrop-blur-sm text-white hover:bg-black/70"
+                  onClick={goNext}
+                  aria-label="Next image"
+                  data-testid="lightbox-next"
+                >
+                  <ChevronRight className="h-6 w-6" />
+                </Button>
+              </div>
             )}
           </DialogPrimitive.Content>
         </DialogPrimitive.Overlay>


### PR DESCRIPTION
## Summary

Fixes [#19](https://github.com/JohanX/mindshed/issues/19) — three related lightbox UX issues, plus a side-effect of moving to viewport-anchored controls.

- **Buttons land on the image with small images.** Story 29.1 makes desktop `DialogContent` shrink to wrap the image; absolute-positioned controls sat at the image edges. Small `LINK`-type photos (e.g. ~485 px from a `w_800` Cloudinary URL) put close/prev/next on top of the image. Fix: `position: fixed` on controls, anchored to the viewport.
- **Prev/Next jump ~22 px down on press.** Tailwind v4 stores translate-x and translate-y in a single CSS variable; `<Button>`'s `active:translate-y-px` press cue replaced the `-translate-y-1/2` vertical centering on the same element. Fix: wrap the Button in a positioner div so the wrapper carries the centering and the Button carries the press transform — no collision.
- **Slow clicks don't fire on prev/next.** Same root cause as the jump. The button drops out from under the cursor over 150 ms; `click` only fires when mouseup is on the same element as mousedown. Fixed by the same wrapper restructure.
- **Orange focus ring on close button on every mouse-click open.** Radix auto-focused the first focusable inside Content (close button); browsers match `:focus-visible` on programmatic `.focus()` that follows a click. Fix: `onOpenAutoFocus={(e) => e.preventDefault()}` skips the initial focus move; Tab into the dialog still works for keyboard users.

The viewport-anchored `fixed` positioning required dropping `transform: scale` from the lightbox keyframes. A `transform` on a `fixed` descendant's ancestor establishes a new containing block, and the buttons would visibly jump to viewport edges at end-of-animation (verified live: ~450 px jump on desktop with a small image). The lightbox now uses opacity-only `anim-lightbox-reveal`/`anim-lightbox-settle` keyframes in `src/app/globals.css`. Dialog and popup surfaces keep the shared `anim-reveal`/`anim-settle` with the small scale effect untouched.

Story 29.1's image-bounded backdrop dismiss, Story 29.6 swipe gestures, Story 32.3 layoutId morph, Story 34.1 swipe-during-morph, and Story 34.4 size stabilization all remain intact with passing E2E coverage.

## Files changed

- `src/components/image/image-lightbox.tsx` — controls switch from `absolute` to `fixed`; prev/next wrapped in positioner divs; `onOpenAutoFocus.preventDefault()` added; comments updated.
- `src/app/globals.css` — new `anim-lightbox-reveal`/`anim-lightbox-settle` opacity-only keyframes scoped to the lightbox.
- `e2e/lightbox-controls.spec.ts` — new regression tests for all three issues.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test run` — 1003 passed
- [x] `pnpm build`
- [x] `pnpm test:e2e:chrome` — **189 / 189 passed** (no flaky failures)
- [x] Manual: live verification on local dev confirmed close.x stays at 1144 from t=50 ms onwards (no jump), `closeAriaHiddenAncestor=null`, `focusedTag=BODY` (no orange ring on close).
- [ ] Vercel preview spot-check on https://mindshed.johan.ro/gallery/pairing-knife: open the first image, confirm close/prev/next sit at viewport corners (not on the image), confirm prev/next press is a clean 1 px nudge, confirm slow clicks fire, confirm no orange ring on close.

## Code review notes

Ran `bmad-code-review` (Blind Hunter + Edge Case Hunter). Edge Case Hunter raised a BLOCKER on an earlier draft that placed controls outside `DialogContent`: the `anim-lightbox-content` keyframe animates `transform: scale(0.95) → 1`, and a transformed ancestor breaks `fixed` positioning during the animation — empirically verified as a ~450 px jump at end of animation, plus Radix's `aria-hidden` modal management was marking the new sibling-of-Content controls as aria-hidden (breaking screen readers and `getByRole` Playwright queries). The current PR addresses both by keeping controls inside `DialogContent` and switching the lightbox keyframes to opacity-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)