### PR TITLE
Story 35.1: Step video upload foundation — schema + adapter video methods + cascade widening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,4 @@ That's the developer's footgun; don't `--no-verify` casually.
 - `src/lib/r2.ts` — S3Client, `getPublicUrl()`, `deleteObject()`
 - Docker `minio-init` service auto-creates bucket with CORS
 - Use `<img>` not `next/image` for MinIO URLs (private IP block in dev)
+- **Video (Epic 35 / FR134, FR137):** `ImageStorageAdapter` exposes `getVideoUrl`, `getVideoPosterUrl` (returns `null` on S3 — UI renders generic play-icon card; Cloudinary derives via `so_auto` URL transform), and `mediaType` opts on `deleteObject` / `upload`. **Load-bearing footgun:** Cloudinary `destroy()` and `upload()` MUST receive `resource_type: 'video'` (via `{ mediaType: 'video' }`) for video assets — otherwise the SDK silently routes through the `image` pipeline and orphans the bytes. See `_bmad-output/planning-artifacts/architecture.md` § "Image Storage Adapter — Video Methods" for the full contract.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Only needed if using R2 for image storage. Configure CORS on your R2 bucket:
 - **Styling:** Tailwind CSS v4 + shadcn/ui v4
 - **Database:** PostgreSQL via Prisma 7 (Supabase/Neon in production, Docker locally)
 - **Image Storage:** Cloudinary (recommended) or S3-compatible (R2, MinIO locally)
+  - Video support (Epic 35): both adapters store and serve video. Only Cloudinary derives **poster frames** via the `so_auto` URL transform; the S3-compatible adapter returns `null` from `getVideoPosterUrl` and the UI renders a generic play-icon card at tile size. Lightbox playback is identical on both adapters. See [`_bmad-output/planning-artifacts/architecture.md`](../_bmad-output/planning-artifacts/architecture.md) § "Image Storage Adapter — Video Methods" for the full pattern.
 - **Testing:** Vitest + Playwright
 
 ## License

--- a/prisma/migrations/20260512070806_step_image_media_type/migration.sql
+++ b/prisma/migrations/20260512070806_step_image_media_type/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "StepMediaType" AS ENUM ('IMAGE', 'VIDEO');
+
+-- AlterTable
+ALTER TABLE "step_image" ADD COLUMN     "duration_seconds" INTEGER,
+ADD COLUMN     "media_type" "StepMediaType" NOT NULL DEFAULT 'IMAGE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -252,6 +252,11 @@ enum StepImageType {
   LINK
 }
 
+enum StepMediaType {
+  IMAGE
+  VIDEO
+}
+
 model StepImage {
   id               String        @id @default(uuid())
   stepId           String        @map("step_id")
@@ -260,6 +265,8 @@ model StepImage {
   contentType      String?       @map("content_type")
   sizeBytes        Int?          @map("size_bytes")
   type             StepImageType @default(UPLOAD)
+  mediaType        StepMediaType @default(IMAGE) @map("media_type")
+  durationSeconds  Int?          @map("duration_seconds")
   url              String?
   createdAt        DateTime      @default(now()) @map("created_at")
 

--- a/src/actions/__tests__/hobby.test.ts
+++ b/src/actions/__tests__/hobby.test.ts
@@ -340,7 +340,10 @@ describe('deleteHobby', () => {
           type: 'UPLOAD',
           storageKey: { not: null },
         },
-        select: { storageKey: true },
+        // Story 35.1: step_image collection adds mediaType to the select
+        // so the cleanup helper can route resource_type:'video' to
+        // Cloudinary's destroy() for video rows.
+        select: { storageKey: true, mediaType: true },
       })
       expect(ideaImageFindMany).toHaveBeenCalledWith({
         where: {
@@ -348,6 +351,7 @@ describe('deleteHobby', () => {
           type: 'UPLOAD',
           storageKey: { not: null },
         },
+        // idea_image does NOT gain mediaType in V1 (FR134 step-image only)
         select: { storageKey: true },
       })
       // 1 step image + 2 idea images = 3 total deletions

--- a/src/actions/__tests__/image.test.ts
+++ b/src/actions/__tests__/image.test.ts
@@ -450,6 +450,8 @@ describe('deleteStepImage', () => {
     mockAdapter.mockReturnValue({
       getPublicUrl: vi.fn(),
       getThumbnailUrl: vi.fn(),
+      getVideoUrl: vi.fn(),
+      getVideoPosterUrl: vi.fn().mockReturnValue(null),
       deleteObject: mockDeleteObj,
       generatePresignedUrl: vi.fn(),
       upload: vi.fn(),
@@ -474,6 +476,8 @@ describe('deleteStepImage', () => {
     mockAdapter.mockReturnValue({
       getPublicUrl: vi.fn(),
       getThumbnailUrl: vi.fn(),
+      getVideoUrl: vi.fn(),
+      getVideoPosterUrl: vi.fn().mockReturnValue(null),
       deleteObject: mockDeleteObj,
       generatePresignedUrl: vi.fn(),
       upload: vi.fn(),
@@ -497,6 +501,8 @@ describe('deleteStepImage', () => {
     mockAdapter.mockReturnValue({
       getPublicUrl: vi.fn(),
       getThumbnailUrl: vi.fn(),
+      getVideoUrl: vi.fn(),
+      getVideoPosterUrl: vi.fn().mockReturnValue(null),
       deleteObject: mockDeleteObj,
       generatePresignedUrl: vi.fn(),
       upload: vi.fn(),

--- a/src/actions/__tests__/project-delete.test.ts
+++ b/src/actions/__tests__/project-delete.test.ts
@@ -122,7 +122,7 @@ describe('deleteProject', () => {
           type: 'UPLOAD',
           storageKey: { not: null },
         },
-        select: { storageKey: true },
+        select: { storageKey: true, mediaType: true },
       })
       expect(deleteObject).toHaveBeenCalledTimes(3)
     })

--- a/src/actions/__tests__/step.test.ts
+++ b/src/actions/__tests__/step.test.ts
@@ -173,9 +173,14 @@ describe('deleteStep', () => {
         deleteObject,
       } as unknown as ReturnType<typeof getImageStorageAdapter>)
 
-      const stepImageFindMany = vi
-        .fn()
-        .mockResolvedValue([{ storageKey: 'steps/abc/1.jpg' }, { storageKey: 'steps/abc/2.jpg' }])
+      // Story 35.1: explicit mediaType in mock rows mirrors the
+      // production NOT NULL DEFAULT 'IMAGE' contract — guards against
+      // a future Prisma refactor that surfaces mediaType differently
+      // and lets the VIDEO sibling test below share the same shape.
+      const stepImageFindMany = vi.fn().mockResolvedValue([
+        { storageKey: 'steps/abc/1.jpg', mediaType: 'IMAGE' },
+        { storageKey: 'steps/abc/2.jpg', mediaType: 'IMAGE' },
+      ])
       mockTransaction.mockImplementation(async (fn) => {
         const tx = {
           step: {
@@ -198,11 +203,51 @@ describe('deleteStep', () => {
           type: 'UPLOAD',
           storageKey: { not: null },
         },
-        select: { storageKey: true },
+        select: { storageKey: true, mediaType: true },
       })
       expect(deleteObject).toHaveBeenCalledTimes(2)
-      expect(deleteObject).toHaveBeenCalledWith('steps/abc/1.jpg')
-      expect(deleteObject).toHaveBeenCalledWith('steps/abc/2.jpg')
+      // Story 35.1: helper passes { mediaType } to adapter. Mock rows
+      // are explicitly IMAGE, so the cleanup call carries that opt.
+      expect(deleteObject).toHaveBeenCalledWith('steps/abc/1.jpg', { mediaType: 'image' })
+      expect(deleteObject).toHaveBeenCalledWith('steps/abc/2.jpg', { mediaType: 'image' })
+    })
+
+    it('routes mediaType:"video" to adapter.deleteObject for VIDEO rows (Story 35.1 / FR137)', async () => {
+      // Locks in the action → cleanupStorageKeys → adapter.deleteObject
+      // routing for the VIDEO branch. Without this test, removing the
+      // `mediaType === 'VIDEO' ? 'video' : 'image'` mapping in
+      // step.ts would still keep the IMAGE-branch tests green —
+      // silently regressing the FR137 / Epic 28 load-bearing contract
+      // (Cloudinary destroy() needs resource_type:'video' or the
+      // bytes orphan).
+      const deleteObject = vi.fn().mockResolvedValue(undefined)
+      mockGetAdapter.mockReturnValue({
+        deleteObject,
+      } as unknown as ReturnType<typeof getImageStorageAdapter>)
+
+      const stepImageFindMany = vi.fn().mockResolvedValue([
+        { storageKey: 'steps/abc/clip.mp4', mediaType: 'VIDEO' },
+        { storageKey: 'steps/abc/photo.jpg', mediaType: 'IMAGE' },
+      ])
+      mockTransaction.mockImplementation(async (fn) => {
+        const tx = {
+          step: {
+            findUniqueOrThrow: vi
+              .fn()
+              .mockResolvedValue({ projectId: 'p1', project: { isCompleted: false } }),
+            delete: vi.fn().mockResolvedValue({ id: 's1', projectId: 'p1' }),
+          },
+          reminder: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          stepImage: { findMany: stepImageFindMany },
+        }
+        return fn(tx as never)
+      })
+
+      const result = await deleteStep('550e8400-e29b-41d4-a716-446655440000')
+      expect(result.success).toBe(true)
+      expect(deleteObject).toHaveBeenCalledTimes(2)
+      expect(deleteObject).toHaveBeenCalledWith('steps/abc/clip.mp4', { mediaType: 'video' })
+      expect(deleteObject).toHaveBeenCalledWith('steps/abc/photo.jpg', { mediaType: 'image' })
     })
 
     it('still returns success when adapter.deleteObject throws', async () => {

--- a/src/actions/hobby.ts
+++ b/src/actions/hobby.ts
@@ -119,6 +119,8 @@ export async function deleteHobby(id: string): Promise<ActionResult<null>> {
       // affected image BEFORE the delete. Two paths converge under hobby:
       //   step_image (via projects → steps under this hobby)
       //   idea_image (via the hobby's ideas)
+      // Story 35.1 / Epic 35: select mediaType on step_image (idea_image
+      // does NOT gain mediaType in V1; FR134 scope is step images only).
       const stepImageKeys =
         steps.length > 0
           ? await tx.stepImage.findMany({
@@ -127,7 +129,7 @@ export async function deleteHobby(id: string): Promise<ActionResult<null>> {
                 type: 'UPLOAD',
                 storageKey: { not: null },
               },
-              select: { storageKey: true },
+              select: { storageKey: true, mediaType: true },
             })
           : []
       const ideaImageKeys = await tx.ideaImage.findMany({
@@ -139,7 +141,16 @@ export async function deleteHobby(id: string): Promise<ActionResult<null>> {
         select: { storageKey: true },
       })
       await tx.hobby.delete({ where: { id: parsed.data } })
-      return [...stepImageKeys, ...ideaImageKeys]
+      // Normalise both shapes for cleanupStorageKeys. step_image rows carry
+      // mediaType (routed to adapter.deleteObject opts); idea_image rows
+      // don't (helper falls through to the no-opts call shape).
+      return [
+        ...stepImageKeys.map(({ storageKey, mediaType }) => ({
+          storageKey,
+          mediaType: (mediaType === 'VIDEO' ? 'video' : 'image') as 'image' | 'video',
+        })),
+        ...ideaImageKeys,
+      ]
     })
 
     // Best-effort post-commit storage cleanup. Failures NEVER fail the

--- a/src/actions/project.ts
+++ b/src/actions/project.ts
@@ -223,7 +223,7 @@ export async function deleteProject(id: string): Promise<ActionResult<{ hobbyId:
   }
 
   try {
-    const { project, storageKeys } = await prisma.$transaction(async (tx) => {
+    const { project, storageKeyRows } = await prisma.$transaction(async (tx) => {
       const steps = await tx.step.findMany({
         where: { projectId: parsed.data },
         select: { id: true },
@@ -233,7 +233,9 @@ export async function deleteProject(id: string): Promise<ActionResult<{ hobbyId:
       // FR122 / Story 28.1: collect step_image storage keys for every
       // step in this project BEFORE the cascade so they're captured
       // atomically with the parent delete.
-      const storageKeys =
+      // Story 35.1 / Epic 35: select mediaType so the cleanup helper can
+      // route resource_type:'video' to Cloudinary's destroy() for video rows.
+      const storageKeyRows =
         steps.length > 0
           ? await tx.stepImage.findMany({
               where: {
@@ -241,16 +243,21 @@ export async function deleteProject(id: string): Promise<ActionResult<{ hobbyId:
                 type: 'UPLOAD',
                 storageKey: { not: null },
               },
-              select: { storageKey: true },
+              select: { storageKey: true, mediaType: true },
             })
           : []
       const project = await tx.project.delete({ where: { id: parsed.data } })
-      return { project, storageKeys }
+      return { project, storageKeyRows }
     })
 
     // Best-effort post-commit storage cleanup. Failures NEVER fail the
     // action — see FR122 best-effort guarantee.
-    await cleanupStorageKeys(storageKeys)
+    await cleanupStorageKeys(
+      storageKeyRows.map(({ storageKey, mediaType }) => ({
+        storageKey,
+        mediaType: mediaType === 'VIDEO' ? 'video' : 'image',
+      })),
+    )
 
     revalidatePath(`/hobbies/${project.hobbyId}`)
     revalidatePath('/projects')

--- a/src/actions/step.ts
+++ b/src/actions/step.ts
@@ -111,7 +111,7 @@ export async function deleteStep(id: string): Promise<ActionResult<null>> {
   }
 
   try {
-    const { step, storageKeys } = await prisma.$transaction(async (tx) => {
+    const { step, storageKeyRows } = await prisma.$transaction(async (tx) => {
       const existing = await tx.step.findUniqueOrThrow({
         where: { id: parsed.data },
         select: { projectId: true, project: { select: { isCompleted: true } } },
@@ -120,22 +120,29 @@ export async function deleteStep(id: string): Promise<ActionResult<null>> {
       await tx.reminder.deleteMany({ where: { targetId: parsed.data } })
       // FR122 / Story 28.1: collect storage keys BEFORE the cascade so
       // they're atomically captured with the parent delete.
-      const storageKeys = await tx.stepImage.findMany({
+      // Story 35.1 / Epic 35: select mediaType so the cleanup helper can
+      // route resource_type:'video' to Cloudinary's destroy() for video rows.
+      const storageKeyRows = await tx.stepImage.findMany({
         where: {
           stepId: parsed.data,
           type: 'UPLOAD',
           storageKey: { not: null },
         },
-        select: { storageKey: true },
+        select: { storageKey: true, mediaType: true },
       })
       const step = await tx.step.delete({ where: { id: parsed.data } })
-      return { step, storageKeys }
+      return { step, storageKeyRows }
     })
 
     // Best-effort post-commit storage cleanup (does NOT run if the tx
     // aborted via PROJECT_COMPLETED above — destructuring would have
     // already thrown).
-    await cleanupStorageKeys(storageKeys)
+    await cleanupStorageKeys(
+      storageKeyRows.map(({ storageKey, mediaType }) => ({
+        storageKey,
+        mediaType: mediaType === 'VIDEO' ? 'video' : 'image',
+      })),
+    )
 
     await updateProjectActivity(step.projectId)
     return { success: true, data: null }

--- a/src/app/(app)/api/upload/__tests__/presign.test.ts
+++ b/src/app/(app)/api/upload/__tests__/presign.test.ts
@@ -110,6 +110,8 @@ describe('POST /api/upload/presign', () => {
     mockAdapter.mockReturnValue({
       getPublicUrl: vi.fn(),
       getThumbnailUrl: vi.fn(),
+      getVideoUrl: vi.fn(),
+      getVideoPosterUrl: vi.fn().mockReturnValue(null),
       deleteObject: vi.fn(),
       generatePresignedUrl: mockPresign,
       upload: vi.fn(),
@@ -144,6 +146,8 @@ describe('POST /api/upload/presign', () => {
     mockAdapter.mockReturnValue({
       getPublicUrl: vi.fn(),
       getThumbnailUrl: vi.fn(),
+      getVideoUrl: vi.fn(),
+      getVideoPosterUrl: vi.fn().mockReturnValue(null),
       deleteObject: vi.fn(),
       generatePresignedUrl: vi.fn().mockRejectedValue(new Error('does not support presigned URLs')),
       upload: vi.fn(),

--- a/src/lib/__tests__/storage-cleanup.test.ts
+++ b/src/lib/__tests__/storage-cleanup.test.ts
@@ -105,4 +105,67 @@ describe('cleanupStorageKeys', () => {
 
     expect(deleteObject).not.toHaveBeenCalled()
   })
+
+  it('routes opts.mediaType to deleteObject per entry (Epic 35)', async () => {
+    // Mixed-media cascade: a step with 2 IMAGE + 1 VIDEO rows triggers
+    // 3 deleteObject calls; the VIDEO call MUST carry { mediaType: 'video' }
+    // so the Cloudinary adapter passes resource_type:'video' (load-bearing
+    // for FR122 / FR137 — without it, video bytes are orphaned).
+    const deleteObject = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getImageStorageAdapter).mockReturnValue({
+      deleteObject,
+    } as unknown as ReturnType<typeof getImageStorageAdapter>)
+
+    await cleanupStorageKeys([
+      { storageKey: 'steps/abc/1.jpg', mediaType: 'image' },
+      { storageKey: 'steps/abc/2.jpg', mediaType: 'image' },
+      { storageKey: 'steps/abc/3.mp4', mediaType: 'video' },
+    ])
+
+    expect(deleteObject).toHaveBeenCalledTimes(3)
+    expect(deleteObject).toHaveBeenCalledWith('steps/abc/1.jpg', { mediaType: 'image' })
+    expect(deleteObject).toHaveBeenCalledWith('steps/abc/2.jpg', { mediaType: 'image' })
+    expect(deleteObject).toHaveBeenCalledWith('steps/abc/3.mp4', { mediaType: 'video' })
+  })
+
+  it('preserves the pre-35.1 call shape when mediaType is absent (back-compat)', async () => {
+    // Callers that haven't been widened (e.g., deleteIdea's idea_image
+    // collection, which doesn't gain mediaType in V1) must continue to
+    // call deleteObject(key) with NO opts arg — proves the optional
+    // widening doesn't break the existing IMAGE-only contract.
+    const deleteObject = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getImageStorageAdapter).mockReturnValue({
+      deleteObject,
+    } as unknown as ReturnType<typeof getImageStorageAdapter>)
+
+    await cleanupStorageKeys([
+      { storageKey: 'ideas/xyz/photo.jpg' },
+      { storageKey: 'ideas/xyz/cover.jpg' },
+    ])
+
+    expect(deleteObject).toHaveBeenCalledTimes(2)
+    // No second arg — the helper omits opts when mediaType is undefined.
+    expect(deleteObject).toHaveBeenNthCalledWith(1, 'ideas/xyz/photo.jpg')
+    expect(deleteObject).toHaveBeenNthCalledWith(2, 'ideas/xyz/cover.jpg')
+  })
+
+  it('handles mixed mediaType-present and mediaType-absent entries in one call (Epic 35)', async () => {
+    // deleteHobby collapses step_image (has mediaType) and idea_image (no
+    // mediaType) into one cleanup call. Both shapes must coexist.
+    const deleteObject = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getImageStorageAdapter).mockReturnValue({
+      deleteObject,
+    } as unknown as ReturnType<typeof getImageStorageAdapter>)
+
+    await cleanupStorageKeys([
+      { storageKey: 'steps/abc/vid.mp4', mediaType: 'video' },
+      { storageKey: 'ideas/xyz/photo.jpg' },
+      { storageKey: 'steps/abc/img.jpg', mediaType: 'image' },
+    ])
+
+    expect(deleteObject).toHaveBeenCalledTimes(3)
+    expect(deleteObject).toHaveBeenCalledWith('steps/abc/vid.mp4', { mediaType: 'video' })
+    expect(deleteObject).toHaveBeenNthCalledWith(2, 'ideas/xyz/photo.jpg')
+    expect(deleteObject).toHaveBeenCalledWith('steps/abc/img.jpg', { mediaType: 'image' })
+  })
 })

--- a/src/lib/image-storage/__tests__/cloudinary.test.ts
+++ b/src/lib/image-storage/__tests__/cloudinary.test.ts
@@ -13,6 +13,7 @@ vi.mock('cloudinary', () => ({
   },
 }))
 
+import { v2 as cloudinary } from 'cloudinary'
 import { createCloudinaryAdapter } from '../cloudinary'
 
 describe('CloudinaryStorageAdapter', () => {
@@ -77,9 +78,84 @@ describe('CloudinaryStorageAdapter', () => {
   })
 
   describe('deleteObject', () => {
-    it('calls cloudinary.uploader.destroy', async () => {
+    it('calls cloudinary.uploader.destroy with resource_type:image by default', async () => {
       const adapter = createCloudinaryAdapter()
       await expect(adapter.deleteObject('mindshed/steps/abc/img')).resolves.toBeUndefined()
+      expect(cloudinary.uploader.destroy).toHaveBeenCalledWith('mindshed/steps/abc/img', {
+        resource_type: 'image',
+      })
+    })
+
+    it('passes resource_type:image when opts.mediaType is image (Epic 35)', async () => {
+      const adapter = createCloudinaryAdapter()
+      await adapter.deleteObject('mindshed/steps/abc/img', { mediaType: 'image' })
+      expect(cloudinary.uploader.destroy).toHaveBeenCalledWith('mindshed/steps/abc/img', {
+        resource_type: 'image',
+      })
+    })
+
+    it('passes resource_type:video when opts.mediaType is video (Epic 35, load-bearing)', async () => {
+      // Without resource_type:'video', Cloudinary's destroy() silently
+      // returns 'not found' and orphans the video bytes — defeats FR122.
+      const adapter = createCloudinaryAdapter()
+      await adapter.deleteObject('mindshed/steps/abc/vid', { mediaType: 'video' })
+      expect(cloudinary.uploader.destroy).toHaveBeenCalledWith('mindshed/steps/abc/vid', {
+        resource_type: 'video',
+      })
+    })
+  })
+
+  describe('upload', () => {
+    it('passes resource_type:video when opts.mediaType is video (Epic 35)', async () => {
+      const adapter = createCloudinaryAdapter()
+      await adapter.upload(Buffer.from('fake-video-data'), 'steps/abc/vid.mp4', 'video/mp4', {
+        mediaType: 'video',
+      })
+      const call = vi.mocked(cloudinary.uploader.upload).mock.calls.at(-1)
+      expect(call?.[1]).toMatchObject({ resource_type: 'video', format: 'mp4' })
+    })
+
+    it('passes resource_type:image when opts are omitted (back-compat)', async () => {
+      const adapter = createCloudinaryAdapter()
+      await adapter.upload(Buffer.from('fake'), 'steps/abc/img.jpg', 'image/jpeg')
+      const call = vi.mocked(cloudinary.uploader.upload).mock.calls.at(-1)
+      expect(call?.[1]).toMatchObject({ resource_type: 'image' })
+    })
+  })
+
+  describe('getVideoUrl (Epic 35)', () => {
+    it('returns /video/upload/<key> URL', () => {
+      const adapter = createCloudinaryAdapter()
+      const url = adapter.getVideoUrl('mindshed/steps/abc/vid')
+      expect(url).toBe('https://res.cloudinary.com/demo/video/upload/mindshed/steps/abc/vid')
+    })
+
+    it('throws when CLOUDINARY_CLOUD_NAME is missing', () => {
+      const adapter = createCloudinaryAdapter()
+      delete process.env.CLOUDINARY_CLOUD_NAME
+      expect(() => adapter.getVideoUrl('key')).toThrow('Missing CLOUDINARY_CLOUD_NAME')
+    })
+  })
+
+  describe('getVideoPosterUrl (Epic 35)', () => {
+    it('returns so_auto + w_<width> + f_jpg URL', () => {
+      const adapter = createCloudinaryAdapter()
+      const url = adapter.getVideoPosterUrl('mindshed/steps/abc/vid', 800)
+      expect(url).toBe(
+        'https://res.cloudinary.com/demo/video/upload/so_auto,w_800,f_jpg/mindshed/steps/abc/vid.jpg',
+      )
+    })
+
+    it('handles different widths', () => {
+      const adapter = createCloudinaryAdapter()
+      expect(adapter.getVideoPosterUrl('vid', 160)).toContain('w_160')
+      expect(adapter.getVideoPosterUrl('vid', 1200)).toContain('w_1200')
+    })
+
+    it('throws when CLOUDINARY_CLOUD_NAME is missing', () => {
+      const adapter = createCloudinaryAdapter()
+      delete process.env.CLOUDINARY_CLOUD_NAME
+      expect(() => adapter.getVideoPosterUrl('key', 64)).toThrow('Missing CLOUDINARY_CLOUD_NAME')
     })
   })
 

--- a/src/lib/image-storage/__tests__/s3.test.ts
+++ b/src/lib/image-storage/__tests__/s3.test.ts
@@ -93,6 +93,15 @@ describe('S3StorageAdapter', () => {
       const adapter = createS3Adapter()
       await expect(adapter.deleteObject('steps/abc/img.jpg')).resolves.toBeUndefined()
     })
+
+    it('ignores opts.mediaType — DeleteObject is content-type-agnostic (Epic 35)', async () => {
+      // S3 doesn't differentiate by content type at delete time; the opt
+      // is accepted for interface conformance and must not change behaviour.
+      const adapter = createS3Adapter()
+      await expect(adapter.deleteObject('vid.mp4', { mediaType: 'video' })).resolves.toBeUndefined()
+      await expect(adapter.deleteObject('img.jpg', { mediaType: 'image' })).resolves.toBeUndefined()
+      await expect(adapter.deleteObject('any.jpg')).resolves.toBeUndefined()
+    })
   })
 
   describe('upload', () => {
@@ -101,6 +110,40 @@ describe('S3StorageAdapter', () => {
       await expect(adapter.upload(Buffer.from('test'), 'key', 'image/jpeg')).rejects.toThrow(
         'does not support server-side upload',
       )
+    })
+
+    it('throws regardless of opts.mediaType (Epic 35 — opt accepted for interface conformance)', async () => {
+      const adapter = createS3Adapter()
+      await expect(
+        adapter.upload(Buffer.from('test'), 'vid.mp4', 'video/mp4', { mediaType: 'video' }),
+      ).rejects.toThrow('does not support server-side upload')
+    })
+  })
+
+  describe('getVideoUrl (Epic 35)', () => {
+    it('returns the same URL shape as getPublicUrl (S3 serves raw bytes)', () => {
+      const adapter = createS3Adapter()
+      const key = 'steps/abc/vid.mp4'
+      expect(adapter.getVideoUrl(key)).toBe(adapter.getPublicUrl(key))
+    })
+
+    it('respects R2_PUBLIC_URL when set', () => {
+      process.env.R2_PUBLIC_URL = 'https://cdn.example.com'
+      const adapter = createS3Adapter()
+      expect(adapter.getVideoUrl('vid.mp4')).toBe('https://cdn.example.com/test-bucket/vid.mp4')
+    })
+  })
+
+  describe('getVideoPosterUrl (Epic 35)', () => {
+    it('returns null — S3 has no URL-based transformation grammar', () => {
+      const adapter = createS3Adapter()
+      expect(adapter.getVideoPosterUrl('vid.mp4', 800)).toBeNull()
+    })
+
+    it('returns null regardless of width', () => {
+      const adapter = createS3Adapter()
+      expect(adapter.getVideoPosterUrl('vid', 64)).toBeNull()
+      expect(adapter.getVideoPosterUrl('vid', 1200)).toBeNull()
     })
   })
 })

--- a/src/lib/image-storage/adapter.ts
+++ b/src/lib/image-storage/adapter.ts
@@ -12,8 +12,33 @@ export interface ImageStorageAdapter {
    */
   getThumbnailUrl(storageKey: string, width: number): string
 
-  /** Delete a stored image by its storage key */
-  deleteObject(storageKey: string): Promise<void>
+  /**
+   * Get the playable video URL for a stored video by its storage key (Epic 35).
+   * Cloudinary: returns /video/upload/<key> (uses the video delivery pipeline).
+   * S3/R2: returns the same public URL shape as images — browsers play MP4
+   * natively from raw bytes regardless of CDN URL shape.
+   */
+  getVideoUrl(storageKey: string): string
+
+  /**
+   * Get a poster image URL derived from a stored video (Epic 35).
+   * Cloudinary: returns /video/upload/so_auto,w_<width>,f_jpg/<key>.jpg —
+   * so_auto picks a representative frame; f_jpg forces JPEG regardless of
+   * source codec.
+   * S3/R2: returns null — S3 has no transformation grammar. Callers MUST
+   * handle null by rendering a generic play-icon card instead of a poster.
+   */
+  getVideoPosterUrl(storageKey: string, width: number): string | null
+
+  /**
+   * Delete a stored object by its storage key.
+   *
+   * `opts.mediaType` (Epic 35): when 'video', the Cloudinary adapter passes
+   * resource_type:'video' to cloudinary.uploader.destroy. Load-bearing —
+   * without it Cloudinary silently returns 'not found' and orphans the
+   * video bytes. S3-compatible adapters ignore the opt.
+   */
+  deleteObject(storageKey: string, opts?: { mediaType?: 'image' | 'video' }): Promise<void>
 
   /**
    * Generate a presigned URL for direct client-to-storage upload (S3 mode only).
@@ -24,11 +49,15 @@ export interface ImageStorageAdapter {
   /**
    * Upload a file from the server (Cloudinary mode).
    * S3 mode uses presigned URLs instead — throws if called on S3 adapter.
+   *
+   * `opts.mediaType` (Epic 35): when 'video', the Cloudinary adapter passes
+   * resource_type:'video' to cloudinary.uploader.upload.
    */
   upload(
     file: Buffer,
     key: string,
     contentType: string,
+    opts?: { mediaType?: 'image' | 'video' },
   ): Promise<{ publicUrl: string; storageKey: string }>
 }
 

--- a/src/lib/image-storage/cloudinary.ts
+++ b/src/lib/image-storage/cloudinary.ts
@@ -45,8 +45,34 @@ class CloudinaryStorageAdapter implements ImageStorageAdapter {
     return `https://res.cloudinary.com/${cloudName}/image/upload/f_auto,q_auto,w_${width}/${storageKey}`
   }
 
-  async deleteObject(storageKey: string): Promise<void> {
-    await cloudinary.uploader.destroy(storageKey)
+  getVideoUrl(storageKey: string): string {
+    const cloudName = process.env.CLOUDINARY_CLOUD_NAME
+    if (!cloudName) {
+      throw new Error('Missing CLOUDINARY_CLOUD_NAME environment variable.')
+    }
+    // Cloudinary's /video/upload/ pipeline is required for video URLs;
+    // /image/upload/ would 404 for video assets.
+    return `https://res.cloudinary.com/${cloudName}/video/upload/${storageKey}`
+  }
+
+  getVideoPosterUrl(storageKey: string, width: number): string {
+    const cloudName = process.env.CLOUDINARY_CLOUD_NAME
+    if (!cloudName) {
+      throw new Error('Missing CLOUDINARY_CLOUD_NAME environment variable.')
+    }
+    // so_auto picks a representative frame (Cloudinary heuristic — usually
+    // a high-motion frame near the middle); f_jpg forces JPEG output
+    // regardless of source codec; w_<width> sizes the poster for tile use.
+    return `https://res.cloudinary.com/${cloudName}/video/upload/so_auto,w_${width},f_jpg/${storageKey}.jpg`
+  }
+
+  async deleteObject(storageKey: string, opts?: { mediaType?: 'image' | 'video' }): Promise<void> {
+    // LOAD-BEARING: Cloudinary's destroy() defaults to resource_type:'image'.
+    // Calling it on a video key without resource_type:'video' silently
+    // returns { result: 'not found' } and orphans the video bytes — defeats
+    // the FR122 cascade-cleanup contract for video (Story 35.1 / Epic 35).
+    const resourceType = opts?.mediaType === 'video' ? 'video' : 'image'
+    await cloudinary.uploader.destroy(storageKey, { resource_type: resourceType })
   }
 
   async generatePresignedUrl(
@@ -62,14 +88,16 @@ class CloudinaryStorageAdapter implements ImageStorageAdapter {
     file: Buffer,
     key: string,
     contentType: string,
+    opts?: { mediaType?: 'image' | 'video' },
   ): Promise<{ publicUrl: string; storageKey: string }> {
     const ext = contentType.split('/')[1] || 'jpg'
     const dataUri = `data:${contentType};base64,${file.toString('base64')}`
+    const resourceType = opts?.mediaType === 'video' ? 'video' : 'image'
 
     const result = await cloudinary.uploader.upload(dataUri, {
       public_id: key.replace(/\.\w+$/, ''),
       folder: 'mindshed',
-      resource_type: 'image',
+      resource_type: resourceType,
       format: ext,
     })
 

--- a/src/lib/image-storage/s3.ts
+++ b/src/lib/image-storage/s3.ts
@@ -63,7 +63,23 @@ class S3StorageAdapter implements ImageStorageAdapter {
     return this.getPublicUrl(storageKey)
   }
 
-  async deleteObject(storageKey: string): Promise<void> {
+  getVideoUrl(storageKey: string): string {
+    // S3-compatible storage serves raw bytes regardless of content type —
+    // a video stored at key K is reachable at the same URL shape as an
+    // image at key K. Browsers play MP4 natively from this URL.
+    return this.getPublicUrl(storageKey)
+  }
+
+  getVideoPosterUrl(_storageKey: string, _width: number): string | null {
+    // S3 has no URL-based transformation grammar — we cannot derive a poster
+    // frame from the video bytes. Callers MUST render a generic play-icon
+    // card when this returns null (Story 35.1 / Epic 35).
+    return null
+  }
+
+  async deleteObject(storageKey: string, _opts?: { mediaType?: 'image' | 'video' }): Promise<void> {
+    // S3 DeleteObject is content-type-agnostic — the opts.mediaType is
+    // accepted for interface conformance and ignored.
     const client = getClient()
     const bucket = getBucket()
     await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: storageKey }))
@@ -90,6 +106,7 @@ class S3StorageAdapter implements ImageStorageAdapter {
     _file: Buffer,
     _key: string,
     _contentType: string,
+    _opts?: { mediaType?: 'image' | 'video' },
   ): Promise<{ publicUrl: string; storageKey: string }> {
     throw new Error(
       'S3 adapter does not support server-side upload. Use generatePresignedUrl() for client-side direct upload.',

--- a/src/lib/storage-cleanup.ts
+++ b/src/lib/storage-cleanup.ts
@@ -44,7 +44,7 @@ let warnedAdapterUnavailable = false
  * to a list of keys.
  */
 export async function cleanupStorageKeys(
-  keys: ReadonlyArray<{ storageKey: string | null }>,
+  keys: ReadonlyArray<{ storageKey: string | null; mediaType?: 'image' | 'video' }>,
 ): Promise<void> {
   if (keys.length === 0) return
 
@@ -57,22 +57,31 @@ export async function cleanupStorageKeys(
     return
   }
 
-  const validKeys = keys
-    .map((entry) => entry.storageKey)
-    .filter((storageKey): storageKey is string => storageKey !== null && storageKey !== undefined)
+  // Story 35.1 / Epic 35: each entry's mediaType is routed to adapter.deleteObject
+  // so the Cloudinary adapter can pass resource_type:'video' when needed.
+  // Entries without mediaType call deleteObject(key) with no opts — preserves
+  // the pre-35.1 IMAGE-only contract for callers that haven't been widened
+  // (e.g., deleteIdea / idea_image, which doesn't gain mediaType in V1).
+  const validEntries = keys.filter(
+    (entry): entry is { storageKey: string; mediaType?: 'image' | 'video' } =>
+      entry.storageKey !== null && entry.storageKey !== undefined,
+  )
 
-  for (let cursor = 0; cursor < validKeys.length; cursor += STORAGE_CLEANUP_CONCURRENCY) {
-    const chunk = validKeys.slice(cursor, cursor + STORAGE_CLEANUP_CONCURRENCY)
+  for (let cursor = 0; cursor < validEntries.length; cursor += STORAGE_CLEANUP_CONCURRENCY) {
+    const chunk = validEntries.slice(cursor, cursor + STORAGE_CLEANUP_CONCURRENCY)
     await Promise.allSettled(
-      chunk.map((storageKey) =>
-        adapter.deleteObject(storageKey).catch((error: unknown) => {
+      chunk.map((entry) => {
+        const promise = entry.mediaType
+          ? adapter.deleteObject(entry.storageKey, { mediaType: entry.mediaType })
+          : adapter.deleteObject(entry.storageKey)
+        return promise.catch((error: unknown) => {
           // Per-key catch so one bad key in a chunk doesn't reject the
           // outer promise (allSettled would log the rejection; we want
           // a clean console.error path that matches the sequential
           // version's contract).
           console.error('Storage cleanup failed:', error)
-        }),
-      ),
+        })
+      }),
     )
   }
 }


### PR DESCRIPTION
## Summary

Foundation for Epic 35 (video upload — partial closes #10). Lands schema, adapter contract, and cascade-cleanup wiring that Stories 35.2 (upload path) / 35.3 (owner-side rendering) / 35.4 (public gallery parity + cascade E2E) build on.

- **No user-visible UI in this story.** First user-facing surface is Story 35.2.
- **Issue #10 stays open** until Story 35.4 lands the end-to-end MinIO video round-trip. This PR is one of four building toward that close.

## What's in this PR

**Schema**
- New `StepMediaType` enum (`IMAGE` | `VIDEO`) on `step_image`.
- `media_type StepMediaType @default(IMAGE)` — existing 893+ rows backfill via column DEFAULT (verified `SELECT COUNT(*) WHERE media_type IS NULL → 0` post-apply).
- `duration_seconds Int?` — populated on VIDEO rows only.
- Migration `20260512070806_step_image_media_type/` (full `YYYYMMDDHHMMSS_` prefix per Story 31.1).
- Idea/inventory image tables intentionally **unchanged** — V1 scope is step images only (FR134).

**Adapter (`ImageStorageAdapter` widened additively)**
- `getVideoUrl(key)` — Cloudinary returns `/video/upload/<key>`; S3 returns same shape as `getPublicUrl`.
- `getVideoPosterUrl(key, width)` — Cloudinary returns `/video/upload/so_auto,w_<w>,f_jpg/<key>.jpg`; **S3 returns `null`** (UI renders a generic play-icon card).
- `deleteObject` + `upload` accept optional `{ mediaType?: 'image' | 'video' }`. Existing image-only callers unchanged.

**Cloudinary load-bearing routing** ⚠️
- `destroy()` and `upload()` pass `resource_type: 'video'` when `mediaType === 'video'`. **Without this, Cloudinary silently returns `not found` on video keys and orphans the bytes.** Single highest-risk piece of the change set; covered by direct unit tests asserting propagation.

**Cascade cleanup (Story 28.1 helper widening)**
- `cleanupStorageKeys` input shape widened additively to `{ storageKey, mediaType? }`. Entries without `mediaType` keep the pre-35.1 `deleteObject(key)` call shape.
- `deleteStep` / `deleteProject` / `deleteHobby` select `mediaType` from `step_image` and map `VIDEO → 'video'` / `IMAGE → 'image'` per entry.
- `deleteInventoryItem` soft-delete + `deleteIdea` intentionally **NOT** widened — those tables don't gain `mediaType` in V1.
- `deleteHobby` collapses step_image (with mediaType) + idea_image (without mediaType) shapes; helper handles both.

**Tests (13 new)**
- Cloudinary (5): URL shapes, missing-env guards, `destroy()` resource_type routing across image/video/default, `upload()` resource_type routing.
- S3 (4): `getVideoUrl` mirror, `R2_PUBLIC_URL` respected, `getVideoPosterUrl` returns null, opt-ignored `deleteObject`/`upload`.
- storage-cleanup (3): mediaType routing per entry, pre-35.1 back-compat (no mediaType key), mixed-shape entry list.
- step action (1): mixed IMAGE+VIDEO mock asserts adapter receives correct opts per row (added during code review patch phase).
- Existing IMAGE-branch tests in `step`/`project-delete`/`hobby` tightened to carry explicit `mediaType:'IMAGE'` (replaces undefined-coerced shape).

**Docs**
- README addendum: S3 vs Cloudinary video-poster asymmetry.
- CLAUDE.md addendum: FR134/FR137 + load-bearing Cloudinary `resource_type` footgun.

## Gate chain

- `pnpm format` ✅
- `pnpm lint` ✅ (0 warnings)
- `pnpm typecheck` ✅ (0 errors)
- `pnpm test run` ✅ **1022/1022 unit pass**
- `pnpm build` ✅
- `pnpm test:e2e:chrome` ⚠️ 186/189 — 1 inventory test flake (`inventory.spec.ts > can edit an inventory item`) confirmed pre-existing on `origin/main` baseline (stashed all Story 35.1 changes, ran the single test — same locator timeout). Unrelated to this PR. Suggest filing as a separate test-reliability ticket (precedent: Stories 18.4 / 19.1 / 31.4).

## Code review

Three-layer adversarial pass (Blind Hunter / Edge Case Hunter / Acceptance Auditor). 20 findings → 1 patch (applied) / 8 defers (recorded) / 11 dismissed.

- **Patch (applied):** added VIDEO-branch routing test to `step.test.ts` mixed IMAGE+VIDEO mock — locks in the action → helper → adapter wiring against future regression.
- **Critical defer (must land in Story 35.2):** single-image delete in `image.ts:deleteStepImage` + DB-rollback orphan-cleanup paths in `image.ts`/`idea-image.ts`/`inventory-image.ts` don't route `mediaType`. Dormant in 35.1 (no VIDEO rows exist yet); live bug the moment 35.2 enables video upload. Recorded in `_bmad-output/implementation-artifacts/deferred-work.md`.
- **Acceptance Auditor verdict:** 10/10 ACs ✅ (AC10 ⚠️ partial due to the pre-existing E2E flake).

## Test plan

- [ ] Pull the branch locally and run `pnpm test run` — expect 1022/1022.
- [ ] Run `pnpm prisma migrate deploy --schema prisma/schema.prisma` against a fresh dev DB — expect the new migration to apply cleanly.
- [ ] Verify in psql: `SELECT mediaType, duration_seconds FROM step_image LIMIT 5` returns IMAGE/NULL on existing rows.
- [ ] Spot-check `src/lib/image-storage/cloudinary.ts` `deleteObject` + `upload` for the `resource_type: 'video'` routing.
- [ ] Spot-check `src/lib/storage-cleanup.ts` for the back-compat: entries with no `mediaType` field call `deleteObject(key)` with no opts.
- [ ] Confirm `_bmad-output/implementation-artifacts/deferred-work.md` lists the HIGH-severity defer that must land in 35.2.

Ref: Story 35.1 — `_bmad-output/implementation-artifacts/35-1-schema-migration-and-adapter-video-methods.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)